### PR TITLE
feat(retail): アラート管理機能バックエンドAPI (Issue #15)

### DIFF
--- a/backend/src/main/java/com/youlai/boot/modules/retail/controller/AlertController.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/controller/AlertController.java
@@ -4,10 +4,13 @@ import com.youlai.boot.common.result.PageResult;
 import com.youlai.boot.common.result.Result;
 import com.youlai.boot.modules.retail.model.entity.Alert;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
+import com.youlai.boot.modules.retail.model.form.AlertStatusForm;
 import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
 import com.youlai.boot.modules.retail.model.vo.AlertPageVO;
+import com.youlai.boot.modules.retail.model.vo.AlertVO;
 import com.youlai.boot.modules.retail.service.AlertService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -46,25 +49,29 @@ public class AlertController {
 
     @Operation(summary = "アラート更新")
     @PutMapping("/{id}")
-    public Result<?> updateAlert(@PathVariable Long id, @RequestBody @Valid AlertForm form) {
+    public Result<?> updateAlert(
+            @Parameter(description = "アラートID") @PathVariable Long id,
+            @RequestBody @Valid AlertForm form) {
         return Result.judge(alertService.updateAlert(id, form));
     }
 
     @Operation(summary = "アラート削除")
     @DeleteMapping("/{id}")
-    public Result<?> deleteAlert(@PathVariable Long id) {
+    public Result<?> deleteAlert(@Parameter(description = "アラートID") @PathVariable Long id) {
         return Result.judge(alertService.deleteAlert(id));
     }
 
     @Operation(summary = "アラート詳細取得")
     @GetMapping("/{id}")
-    public Result<Alert> getAlert(@PathVariable Long id) {
+    public Result<AlertVO> getAlert(@Parameter(description = "アラートID") @PathVariable Long id) {
         return Result.success(alertService.getAlertById(id));
     }
 
-    @Operation(summary = "アラート解決")
-    @PutMapping("/{id}/resolve")
-    public Result<?> resolveAlert(@PathVariable Long id) {
-        return Result.judge(alertService.resolveAlert(id));
+    @Operation(summary = "アラート状態更新")
+    @PutMapping("/{id}/status")
+    public Result<?> updateAlertStatus(
+            @Parameter(description = "アラートID") @PathVariable Long id,
+            @RequestBody @Valid AlertStatusForm form) {
+        return Result.judge(alertService.updateAlertStatus(id, form));
     }
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/converter/AlertConverter.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/converter/AlertConverter.java
@@ -3,6 +3,7 @@ package com.youlai.boot.modules.retail.converter;
 import com.youlai.boot.modules.retail.model.entity.Alert;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
 import com.youlai.boot.modules.retail.model.vo.AlertPageVO;
+import com.youlai.boot.modules.retail.model.vo.AlertVO;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
 
@@ -29,5 +30,14 @@ public interface AlertConverter {
      * @param entity アラートエンティティ
      * @return アラートページングVO
      */
-    AlertPageVO entity2Vo(Alert entity);
+    AlertPageVO entity2PageVo(Alert entity);
+
+    /**
+     * Alert エンティティから AlertVO への変換
+     * 注意: storeName, productName, productCode, deviceName は別途設定が必要
+     *
+     * @param entity アラートエンティティ
+     * @return アラート詳細VO
+     */
+    AlertVO entity2Vo(Alert entity);
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/job/AlertDetectionJob.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/job/AlertDetectionJob.java
@@ -1,0 +1,88 @@
+package com.youlai.boot.modules.retail.job;
+
+import com.xxl.job.core.handler.annotation.XxlJob;
+import com.youlai.boot.modules.retail.service.AlertService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * アラート検出バッチジョブ
+ *
+ * @author wangjw
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AlertDetectionJob {
+
+    private final AlertService alertService;
+
+    /**
+     * 在庫切れアラート検出（1時間毎に実行を推奨）
+     * 店舗×商品の有効在庫合計が発注点以下の場合にアラートを生成
+     */
+    @XxlJob("lowStockAlertJobHandler")
+    public void detectLowStockAlerts() {
+        log.info("在庫切れアラート検出バッチ開始");
+        try {
+            int count = alertService.detectLowStockAlerts();
+            log.info("在庫切れアラート検出バッチ完了: {}件のアラートを生成", count);
+        } catch (Exception e) {
+            log.error("在庫切れアラート検出バッチ失敗", e);
+            throw e;
+        }
+    }
+
+    /**
+     * 賞味期限接近アラート検出（毎日06:00に実行を推奨）
+     * 有効在庫の賞味期限が7日以内の場合にアラートを生成
+     */
+    @XxlJob("expirySoonAlertJobHandler")
+    public void detectExpirySoonAlerts() {
+        log.info("賞味期限接近アラート検出バッチ開始");
+        try {
+            int count = alertService.detectExpirySoonAlerts();
+            log.info("賞味期限接近アラート検出バッチ完了: {}件のアラートを生成", count);
+        } catch (Exception e) {
+            log.error("賞味期限接近アラート検出バッチ失敗", e);
+            throw e;
+        }
+    }
+
+    /**
+     * 在庫過多アラート検出（毎週月曜09:00に実行を推奨）
+     * 店舗×商品の有効在庫合計が適正在庫上限の1.5倍以上の場合にアラートを生成
+     */
+    @XxlJob("highStockAlertJobHandler")
+    public void detectHighStockAlerts() {
+        log.info("在庫過多アラート検出バッチ開始");
+        try {
+            int count = alertService.detectHighStockAlerts();
+            log.info("在庫過多アラート検出バッチ完了: {}件のアラートを生成", count);
+        } catch (Exception e) {
+            log.error("在庫過多アラート検出バッチ失敗", e);
+            throw e;
+        }
+    }
+
+    /**
+     * 全アラート検出（テスト用）
+     * 全種類のアラートを一括で検出
+     */
+    @XxlJob("allAlertDetectionJobHandler")
+    public void detectAllAlerts() {
+        log.info("全アラート検出バッチ開始");
+        try {
+            int lowStockCount = alertService.detectLowStockAlerts();
+            int expirySoonCount = alertService.detectExpirySoonAlerts();
+            int highStockCount = alertService.detectHighStockAlerts();
+
+            log.info("全アラート検出バッチ完了: LOW_STOCK={}件, EXPIRY_SOON={}件, HIGH_STOCK={}件",
+                    lowStockCount, expirySoonCount, highStockCount);
+        } catch (Exception e) {
+            log.error("全アラート検出バッチ失敗", e);
+            throw e;
+        }
+    }
+}

--- a/backend/src/main/java/com/youlai/boot/modules/retail/mapper/AlertMapper.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/mapper/AlertMapper.java
@@ -1,8 +1,17 @@
 package com.youlai.boot.modules.retail.mapper;
 
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.youlai.boot.modules.retail.model.entity.Alert;
+import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
+import com.youlai.boot.modules.retail.model.vo.AlertPageVO;
+import com.youlai.boot.modules.retail.model.vo.AlertVO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * アラートマッパー
@@ -11,4 +20,59 @@ import org.apache.ibatis.annotations.Mapper;
  */
 @Mapper
 public interface AlertMapper extends BaseMapper<Alert> {
+
+    /**
+     * アラートページング取得（店舗名・商品名付き）
+     *
+     * @param page  ページングオブジェクト
+     * @param query クエリパラメータ
+     * @return ページング結果
+     */
+    IPage<AlertPageVO> getAlertPage(Page<AlertPageVO> page, @Param("query") AlertPageQuery query);
+
+    /**
+     * アラート詳細取得（店舗名・商品名付き）
+     *
+     * @param id アラートID
+     * @return アラート詳細
+     */
+    AlertVO getAlertDetail(@Param("id") Long id);
+
+    /**
+     * 在庫切れアラート対象取得
+     * 店舗×商品の有効在庫合計が発注点以下のデータを取得
+     *
+     * @return 在庫切れ対象リスト（storeId, productId, totalQuantity, reorderPoint）
+     */
+    List<Map<String, Object>> findLowStockTargets();
+
+    /**
+     * 賞味期限接近アラート対象取得
+     * 有効在庫の賞味期限が7日以内のデータを取得
+     *
+     * @return 賞味期限接近対象リスト（storeId, productId, lotNumber, expiryDate, quantity, daysUntilExpiry）
+     */
+    List<Map<String, Object>> findExpirySoonTargets();
+
+    /**
+     * 在庫過多アラート対象取得
+     * 店舗×商品の有効在庫合計が適正在庫上限の1.5倍以上のデータを取得
+     *
+     * @return 在庫過多対象リスト（storeId, productId, totalQuantity, maxStock）
+     */
+    List<Map<String, Object>> findHighStockTargets();
+
+    /**
+     * 未解決アラートの存在チェック
+     *
+     * @param storeId   店舗ID
+     * @param productId 商品ID
+     * @param lotNumber ロット番号（NULL許可）
+     * @param alertType アラートタイプ
+     * @return 未解決アラートが存在する場合はtrue
+     */
+    boolean existsUnresolvedAlert(@Param("storeId") Long storeId,
+                                   @Param("productId") Long productId,
+                                   @Param("lotNumber") String lotNumber,
+                                   @Param("alertType") String alertType);
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/model/entity/Alert.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/model/entity/Alert.java
@@ -28,27 +28,67 @@ public class Alert extends BaseEntity {
     private Long productId;
 
     /**
+     * デバイスID
+     */
+    private Long deviceId;
+
+    /**
      * ロット番号
      */
     private String lotNumber;
 
     /**
-     * アラートタイプ（LOW_STOCK, EXPIRED）
+     * アラートタイプ（LOW_STOCK, EXPIRY_SOON, HIGH_STOCK, COMMUNICATION_DOWN, PAYMENT_TERMINAL_DOWN）
      */
     private String alertType;
 
     /**
+     * 優先度（P1, P2, P3, P4）
+     */
+    private String priority;
+
+    /**
+     * ステータス（NEW, ACK, IN_PROGRESS, RESOLVED, CLOSED）
+     */
+    private String status;
+
+    /**
      * アラートメッセージ
      */
-    private String alertMessage;
+    private String message;
 
     /**
-     * アラート日時
+     * しきい値
      */
-    private LocalDateTime alertDate;
+    private String thresholdValue;
 
     /**
-     * 解決フラグ
+     * 現在値
      */
-    private Boolean resolved;
+    private String currentValue;
+
+    /**
+     * 検知日時
+     */
+    private LocalDateTime detectedAt;
+
+    /**
+     * 確認日時
+     */
+    private LocalDateTime acknowledgedAt;
+
+    /**
+     * 解決日時
+     */
+    private LocalDateTime resolvedAt;
+
+    /**
+     * クローズ日時
+     */
+    private LocalDateTime closedAt;
+
+    /**
+     * 解決メモ
+     */
+    private String resolutionNote;
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/model/form/AlertForm.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/model/form/AlertForm.java
@@ -3,6 +3,7 @@ package com.youlai.boot.modules.retail.model.form;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
 
@@ -22,25 +23,37 @@ public class AlertForm {
     private Long storeId;
 
     @Schema(description = "商品ID")
-    @NotNull(message = "商品IDは必須です")
     private Long productId;
 
+    @Schema(description = "デバイスID")
+    private Long deviceId;
+
     @Schema(description = "ロット番号")
-    @NotBlank(message = "ロット番号は必須です")
     @Size(max = 50, message = "ロット番号は50文字以内で入力してください")
     private String lotNumber;
 
-    @Schema(description = "アラートタイプ（LOW_STOCK, EXPIRED）")
+    @Schema(description = "アラートタイプ（LOW_STOCK, EXPIRY_SOON, HIGH_STOCK, COMMUNICATION_DOWN, PAYMENT_TERMINAL_DOWN）")
     @NotBlank(message = "アラートタイプは必須です")
+    @Pattern(regexp = "^(LOW_STOCK|EXPIRY_SOON|HIGH_STOCK|COMMUNICATION_DOWN|PAYMENT_TERMINAL_DOWN)$", message = "アラートタイプが不正です")
     private String alertType;
 
+    @Schema(description = "優先度（P1, P2, P3, P4）")
+    @NotBlank(message = "優先度は必須です")
+    @Pattern(regexp = "^(P1|P2|P3|P4)$", message = "優先度は P1, P2, P3, P4 のいずれかを指定してください")
+    private String priority;
+
     @Schema(description = "アラートメッセージ")
-    @Size(max = 255, message = "アラートメッセージは255文字以内で入力してください")
-    private String alertMessage;
+    @Size(max = 500, message = "アラートメッセージは500文字以内で入力してください")
+    private String message;
 
-    @Schema(description = "アラート日時")
-    private LocalDateTime alertDate;
+    @Schema(description = "しきい値")
+    @Size(max = 50, message = "しきい値は50文字以内で入力してください")
+    private String thresholdValue;
 
-    @Schema(description = "解決フラグ")
-    private Boolean resolved;
+    @Schema(description = "現在値")
+    @Size(max = 50, message = "現在値は50文字以内で入力してください")
+    private String currentValue;
+
+    @Schema(description = "検知日時")
+    private LocalDateTime detectedAt;
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/model/form/AlertStatusForm.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/model/form/AlertStatusForm.java
@@ -1,0 +1,26 @@
+package com.youlai.boot.modules.retail.model.form;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * アラート状態更新フォーム
+ *
+ * @author wangjw
+ */
+@Schema(description = "アラート状態更新フォーム")
+@Data
+public class AlertStatusForm {
+
+    @Schema(description = "ステータス（NEW, ACK, IN_PROGRESS, RESOLVED, CLOSED）")
+    @NotBlank(message = "ステータスは必須です")
+    @Pattern(regexp = "^(NEW|ACK|IN_PROGRESS|RESOLVED|CLOSED)$", message = "ステータスは NEW, ACK, IN_PROGRESS, RESOLVED, CLOSED のいずれかを指定してください")
+    private String status;
+
+    @Schema(description = "解決メモ（RESOLVED/CLOSED時のみ）")
+    @Size(max = 2000, message = "解決メモは2000文字以内で入力してください")
+    private String resolutionNote;
+}

--- a/backend/src/main/java/com/youlai/boot/modules/retail/model/query/AlertPageQuery.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/model/query/AlertPageQuery.java
@@ -26,15 +26,18 @@ public class AlertPageQuery extends BasePageQuery {
     @Schema(description = "ロット番号")
     private String lotNumber;
 
-    @Schema(description = "アラートタイプ（LOW_STOCK, EXPIRED）")
+    @Schema(description = "アラートタイプ（LOW_STOCK, EXPIRY_SOON, HIGH_STOCK）")
     private String alertType;
 
-    @Schema(description = "アラート日時（開始）")
-    private LocalDateTime alertDateStart;
+    @Schema(description = "優先度（P1, P2, P3, P4）")
+    private String priority;
 
-    @Schema(description = "アラート日時（終了）")
-    private LocalDateTime alertDateEnd;
+    @Schema(description = "ステータス（NEW, ACK, IN_PROGRESS, RESOLVED, CLOSED）")
+    private String status;
 
-    @Schema(description = "解決フラグ")
-    private Boolean resolved;
+    @Schema(description = "検知日時（開始）")
+    private LocalDateTime detectedAtStart;
+
+    @Schema(description = "検知日時（終了）")
+    private LocalDateTime detectedAtEnd;
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/model/vo/AlertVO.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/model/vo/AlertVO.java
@@ -6,13 +6,13 @@ import lombok.Data;
 import java.time.LocalDateTime;
 
 /**
- * アラートページングVO
+ * アラート詳細VO
  *
  * @author wangjw
  */
-@Schema(description = "アラートページングVO")
+@Schema(description = "アラート詳細VO")
 @Data
-public class AlertPageVO {
+public class AlertVO {
 
     @Schema(description = "アラートID")
     private Long id;
@@ -31,6 +31,12 @@ public class AlertPageVO {
 
     @Schema(description = "商品コード")
     private String productCode;
+
+    @Schema(description = "デバイスID")
+    private Long deviceId;
+
+    @Schema(description = "デバイス名")
+    private String deviceName;
 
     @Schema(description = "ロット番号")
     private String lotNumber;
@@ -55,6 +61,18 @@ public class AlertPageVO {
 
     @Schema(description = "検知日時")
     private LocalDateTime detectedAt;
+
+    @Schema(description = "確認日時")
+    private LocalDateTime acknowledgedAt;
+
+    @Schema(description = "解決日時")
+    private LocalDateTime resolvedAt;
+
+    @Schema(description = "クローズ日時")
+    private LocalDateTime closedAt;
+
+    @Schema(description = "解決メモ")
+    private String resolutionNote;
 
     @Schema(description = "作成時間")
     private LocalDateTime createTime;

--- a/backend/src/main/java/com/youlai/boot/modules/retail/service/AlertService.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/service/AlertService.java
@@ -3,8 +3,10 @@ package com.youlai.boot.modules.retail.service;
 import com.youlai.boot.common.result.PageResult;
 import com.youlai.boot.modules.retail.model.entity.Alert;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
+import com.youlai.boot.modules.retail.model.form.AlertStatusForm;
 import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
 import com.youlai.boot.modules.retail.model.vo.AlertPageVO;
+import com.youlai.boot.modules.retail.model.vo.AlertVO;
 
 import java.util.List;
 
@@ -36,7 +38,7 @@ public interface AlertService {
      * @param id アラートID
      * @return アラート詳細
      */
-    Alert getAlertById(Long id);
+    AlertVO getAlertById(Long id);
 
     /**
      * アラート新規作成
@@ -64,12 +66,13 @@ public interface AlertService {
     boolean deleteAlert(Long id);
 
     /**
-     * アラート解決
+     * アラート状態更新
      *
-     * @param id アラートID
-     * @return 解決結果
+     * @param id   アラートID
+     * @param form 状態更新フォーム
+     * @return 更新結果
      */
-    boolean resolveAlert(Long id);
+    boolean updateAlertStatus(Long id, AlertStatusForm form);
 
     /**
      * 最近のアラート取得
@@ -78,4 +81,28 @@ public interface AlertService {
      * @return アラートリスト
      */
     List<Alert> getRecentAlerts(Integer limit);
+
+    /**
+     * 在庫切れアラート検出
+     * 店舗×商品の有効在庫合計が発注点以下の場合にアラートを生成
+     *
+     * @return 生成されたアラート数
+     */
+    int detectLowStockAlerts();
+
+    /**
+     * 賞味期限接近アラート検出
+     * 有効在庫の賞味期限が7日以内の場合にアラートを生成
+     *
+     * @return 生成されたアラート数
+     */
+    int detectExpirySoonAlerts();
+
+    /**
+     * 在庫過多アラート検出
+     * 店舗×商品の有効在庫合計が適正在庫上限の1.5倍以上の場合にアラートを生成
+     *
+     * @return 生成されたアラート数
+     */
+    int detectHighStockAlerts();
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/AlertServiceImpl.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/AlertServiceImpl.java
@@ -7,93 +7,61 @@ import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.youlai.boot.common.result.PageResult;
 import com.youlai.boot.modules.retail.converter.AlertConverter;
 import com.youlai.boot.modules.retail.mapper.AlertMapper;
-import com.youlai.boot.modules.retail.mapper.ProductMapper;
 import com.youlai.boot.modules.retail.model.entity.Alert;
-import com.youlai.boot.modules.retail.model.entity.Product;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
+import com.youlai.boot.modules.retail.model.form.AlertStatusForm;
 import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
 import com.youlai.boot.modules.retail.model.vo.AlertPageVO;
+import com.youlai.boot.modules.retail.model.vo.AlertVO;
 import com.youlai.boot.modules.retail.service.AlertService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StringUtils;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * アラートサービス実装クラス
  *
  * @author wangjw
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AlertServiceImpl extends ServiceImpl<AlertMapper, Alert> implements AlertService {
 
     private final AlertConverter alertConverter;
-    private final ProductMapper productMapper;
 
     @Override
     public PageResult<AlertPageVO> getAlertPage(AlertPageQuery queryParams) {
-        // ページングパラメータ
-        Page<Alert> page = new Page<>(queryParams.getPageNum(), queryParams.getPageSize());
-
-        // クエリ条件
-        LambdaQueryWrapper<Alert> queryWrapper = new LambdaQueryWrapper<Alert>()
-                .eq(queryParams.getStoreId() != null, Alert::getStoreId, queryParams.getStoreId())
-                .eq(queryParams.getProductId() != null, Alert::getProductId, queryParams.getProductId())
-                .like(StringUtils.hasText(queryParams.getLotNumber()), Alert::getLotNumber, queryParams.getLotNumber())
-                .eq(StringUtils.hasText(queryParams.getAlertType()), Alert::getAlertType, queryParams.getAlertType())
-                .ge(queryParams.getAlertDateStart() != null, Alert::getAlertDate, queryParams.getAlertDateStart())
-                .le(queryParams.getAlertDateEnd() != null, Alert::getAlertDate, queryParams.getAlertDateEnd())
-                .eq(queryParams.getResolved() != null, Alert::getResolved, queryParams.getResolved())
-                .orderByDesc(Alert::getAlertDate);
-
-        // クエリ実行
-        IPage<Alert> result = this.page(page, queryWrapper);
-
-        // 商品情報取得
-        List<Long> productIds = result.getRecords().stream()
-                .map(Alert::getProductId)
-                .distinct()
-                .collect(Collectors.toList());
-
-        Map<Long, Product> productMap = productMapper.selectBatchIds(productIds).stream()
-                .collect(Collectors.toMap(Product::getId, product -> product));
-
-        // 結果変換
-        List<AlertPageVO> list = result.getRecords().stream()
-                .map(alert -> {
-                    AlertPageVO vo = alertConverter.entity2Vo(alert);
-                    Product product = productMap.get(alert.getProductId());
-                    if (product != null) {
-                        vo.setProductName(product.getProductName());
-                        vo.setProductCode(product.getProductCode());
-                    }
-                    return vo;
-                })
-                .collect(Collectors.toList());
-
-        return PageResult.success(list, result.getTotal());
+        Page<AlertPageVO> page = new Page<>(queryParams.getPageNum(), queryParams.getPageSize());
+        IPage<AlertPageVO> result = baseMapper.getAlertPage(page, queryParams);
+        return PageResult.success(result.getRecords(), result.getTotal());
     }
 
     @Override
     public List<Alert> listAlerts() {
-        // 全アラート取得
         LambdaQueryWrapper<Alert> queryWrapper = new LambdaQueryWrapper<Alert>()
-                .orderByDesc(Alert::getAlertDate);
+                .orderByDesc(Alert::getDetectedAt);
         return this.list(queryWrapper);
     }
 
     @Override
-    public Alert getAlertById(Long id) {
-        return this.getById(id);
+    public AlertVO getAlertById(Long id) {
+        return baseMapper.getAlertDetail(id);
     }
 
     @Override
     public boolean createAlert(AlertForm form) {
         Alert alert = alertConverter.form2Entity(form);
+        alert.setStatus("NEW");
+        if (alert.getDetectedAt() == null) {
+            alert.setDetectedAt(LocalDateTime.now());
+        }
         return this.save(alert);
     }
 
@@ -110,25 +78,180 @@ public class AlertServiceImpl extends ServiceImpl<AlertMapper, Alert> implements
     }
 
     @Override
-    public boolean resolveAlert(Long id) {
+    @Transactional
+    public boolean updateAlertStatus(Long id, AlertStatusForm form) {
         Alert alert = this.getById(id);
         if (alert == null) {
             return false;
         }
-        alert.setResolved(true);
+
+        String newStatus = form.getStatus();
+        LocalDateTime now = LocalDateTime.now();
+
+        // 状態遷移に応じた日時更新
+        switch (newStatus) {
+            case "ACK":
+                alert.setAcknowledgedAt(now);
+                break;
+            case "RESOLVED":
+                alert.setResolvedAt(now);
+                if (form.getResolutionNote() != null) {
+                    alert.setResolutionNote(form.getResolutionNote());
+                }
+                break;
+            case "CLOSED":
+                alert.setClosedAt(now);
+                if (form.getResolutionNote() != null) {
+                    alert.setResolutionNote(form.getResolutionNote());
+                }
+                break;
+        }
+
+        alert.setStatus(newStatus);
         return this.updateById(alert);
     }
 
     @Override
     public List<Alert> getRecentAlerts(Integer limit) {
-        // limitの値を検証・正規化
         if (limit == null || limit <= 0 || limit > 1000) {
-            limit = 10;  // デフォルト値
+            limit = 10;
         }
-        
+
         LambdaQueryWrapper<Alert> queryWrapper = new LambdaQueryWrapper<Alert>()
-                .orderByDesc(Alert::getAlertDate)
+                .orderByDesc(Alert::getDetectedAt)
                 .last("LIMIT " + limit);
         return this.list(queryWrapper);
+    }
+
+    @Override
+    @Transactional
+    public int detectLowStockAlerts() {
+        List<Map<String, Object>> targets = baseMapper.findLowStockTargets();
+        int count = 0;
+
+        for (Map<String, Object> target : targets) {
+            Long storeId = ((Number) target.get("storeId")).longValue();
+            Long productId = ((Number) target.get("productId")).longValue();
+            Integer totalQuantity = ((Number) target.get("totalQuantity")).intValue();
+            Integer reorderPoint = ((Number) target.get("reorderPoint")).intValue();
+            String productName = (String) target.get("productName");
+            String storeName = (String) target.get("storeName");
+
+            // 未解決アラートが存在する場合はスキップ
+            if (baseMapper.existsUnresolvedAlert(storeId, productId, null, "LOW_STOCK")) {
+                continue;
+            }
+
+            Alert alert = new Alert();
+            alert.setStoreId(storeId);
+            alert.setProductId(productId);
+            alert.setAlertType("LOW_STOCK");
+            alert.setPriority("P2");
+            alert.setStatus("NEW");
+            alert.setMessage(String.format("[在庫切れ警告] 店舗: %s, 商品: %s, 現在在庫: %d個, 発注点: %d個",
+                    storeName, productName, totalQuantity, reorderPoint));
+            alert.setThresholdValue(String.valueOf(reorderPoint));
+            alert.setCurrentValue(String.valueOf(totalQuantity));
+            alert.setDetectedAt(LocalDateTime.now());
+
+            this.save(alert);
+            count++;
+        }
+
+        log.info("LOW_STOCK alerts detected: {}", count);
+        return count;
+    }
+
+    @Override
+    @Transactional
+    public int detectExpirySoonAlerts() {
+        List<Map<String, Object>> targets = baseMapper.findExpirySoonTargets();
+        int count = 0;
+
+        for (Map<String, Object> target : targets) {
+            Long storeId = ((Number) target.get("storeId")).longValue();
+            Long productId = ((Number) target.get("productId")).longValue();
+            String lotNumber = (String) target.get("lotNumber");
+            LocalDate expiryDate = target.get("expiryDate") instanceof LocalDate
+                    ? (LocalDate) target.get("expiryDate")
+                    : LocalDate.parse(target.get("expiryDate").toString());
+            Integer quantity = ((Number) target.get("quantity")).intValue();
+            Integer daysUntilExpiry = ((Number) target.get("daysUntilExpiry")).intValue();
+            String productName = (String) target.get("productName");
+            String storeName = (String) target.get("storeName");
+
+            // 未解決アラートが存在する場合はスキップ
+            if (baseMapper.existsUnresolvedAlert(storeId, productId, lotNumber, "EXPIRY_SOON")) {
+                continue;
+            }
+
+            // 優先度判定
+            String priority;
+            if (daysUntilExpiry <= 1) {
+                priority = "P1";
+            } else if (daysUntilExpiry <= 3) {
+                priority = "P2";
+            } else {
+                priority = "P3";
+            }
+
+            Alert alert = new Alert();
+            alert.setStoreId(storeId);
+            alert.setProductId(productId);
+            alert.setLotNumber(lotNumber);
+            alert.setAlertType("EXPIRY_SOON");
+            alert.setPriority(priority);
+            alert.setStatus("NEW");
+            alert.setMessage(String.format("[賞味期限接近] 店舗: %s, 商品: %s, ロット: %s, 賞味期限: %s, 残日数: %d日, 在庫数: %d個",
+                    storeName, productName, lotNumber, expiryDate, daysUntilExpiry, quantity));
+            alert.setThresholdValue("7");
+            alert.setCurrentValue(String.valueOf(daysUntilExpiry));
+            alert.setDetectedAt(LocalDateTime.now());
+
+            this.save(alert);
+            count++;
+        }
+
+        log.info("EXPIRY_SOON alerts detected: {}", count);
+        return count;
+    }
+
+    @Override
+    @Transactional
+    public int detectHighStockAlerts() {
+        List<Map<String, Object>> targets = baseMapper.findHighStockTargets();
+        int count = 0;
+
+        for (Map<String, Object> target : targets) {
+            Long storeId = ((Number) target.get("storeId")).longValue();
+            Long productId = ((Number) target.get("productId")).longValue();
+            Integer totalQuantity = ((Number) target.get("totalQuantity")).intValue();
+            Integer maxStock = ((Number) target.get("maxStock")).intValue();
+            String productName = (String) target.get("productName");
+            String storeName = (String) target.get("storeName");
+
+            // 未解決アラートが存在する場合はスキップ
+            if (baseMapper.existsUnresolvedAlert(storeId, productId, null, "HIGH_STOCK")) {
+                continue;
+            }
+
+            Alert alert = new Alert();
+            alert.setStoreId(storeId);
+            alert.setProductId(productId);
+            alert.setAlertType("HIGH_STOCK");
+            alert.setPriority("P3");
+            alert.setStatus("NEW");
+            alert.setMessage(String.format("[在庫過多] 店舗: %s, 商品: %s, 現在在庫: %d個, 適正上限: %d個, 超過率: %.0f%%",
+                    storeName, productName, totalQuantity, maxStock, (double) (totalQuantity - maxStock) / maxStock * 100));
+            alert.setThresholdValue(String.valueOf((int) (maxStock * 1.5)));
+            alert.setCurrentValue(String.valueOf(totalQuantity));
+            alert.setDetectedAt(LocalDateTime.now());
+
+            this.save(alert);
+            count++;
+        }
+
+        log.info("HIGH_STOCK alerts detected: {}", count);
+        return count;
     }
 }

--- a/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/DashboardServiceImpl.java
+++ b/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/DashboardServiceImpl.java
@@ -62,9 +62,9 @@ public class DashboardServiceImpl implements DashboardService {
         kpi.setActiveStoreCount(activeStoreCount != null ? activeStoreCount : 0);
         kpi.setTotalStoreCount(totalStoreCount != null ? totalStoreCount : 0);
 
-        // 未対応アラート数取得
+        // 未対応アラート数取得（NEW, ACK, IN_PROGRESS状態のアラート）
         long pendingAlertCount = alertMapper.selectCount(new LambdaQueryWrapper<Alert>()
-                .eq(Alert::getResolved, false));
+                .notIn(Alert::getStatus, "RESOLVED", "CLOSED"));
         kpi.setPendingAlertCount((int) pendingAlertCount);
 
         // 在庫切れSKU数取得

--- a/backend/src/main/resources/mapper/retail/AlertMapper.xml
+++ b/backend/src/main/resources/mapper/retail/AlertMapper.xml
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.youlai.boot.modules.retail.mapper.AlertMapper">
+
+    <!-- アラートページング取得 -->
+    <select id="getAlertPage" resultType="com.youlai.boot.modules.retail.model.vo.AlertPageVO">
+        SELECT
+            a.id,
+            a.store_id,
+            s.store_name,
+            a.product_id,
+            p.product_name,
+            p.product_code,
+            a.lot_number,
+            a.alert_type,
+            a.priority,
+            a.status,
+            a.message,
+            a.threshold_value,
+            a.current_value,
+            a.detected_at,
+            a.create_time,
+            a.update_time
+        FROM
+            retail_alert a
+        LEFT JOIN
+            retail_store s ON a.store_id = s.id
+        LEFT JOIN
+            retail_product p ON a.product_id = p.id
+        <where>
+            <if test="query.storeId != null">
+                AND a.store_id = #{query.storeId}
+            </if>
+            <if test="query.productId != null">
+                AND a.product_id = #{query.productId}
+            </if>
+            <if test="query.lotNumber != null and query.lotNumber != ''">
+                AND a.lot_number LIKE CONCAT('%', #{query.lotNumber}, '%')
+            </if>
+            <if test="query.alertType != null and query.alertType != ''">
+                AND a.alert_type = #{query.alertType}
+            </if>
+            <if test="query.priority != null and query.priority != ''">
+                AND a.priority = #{query.priority}
+            </if>
+            <if test="query.status != null and query.status != ''">
+                AND a.status = #{query.status}
+            </if>
+            <if test="query.detectedAtStart != null">
+                AND a.detected_at &gt;= #{query.detectedAtStart}
+            </if>
+            <if test="query.detectedAtEnd != null">
+                AND a.detected_at &lt;= #{query.detectedAtEnd}
+            </if>
+        </where>
+        ORDER BY
+            CASE a.priority
+                WHEN 'P1' THEN 1
+                WHEN 'P2' THEN 2
+                WHEN 'P3' THEN 3
+                WHEN 'P4' THEN 4
+                ELSE 5
+            END,
+            a.detected_at DESC
+    </select>
+
+    <!-- アラート詳細取得 -->
+    <select id="getAlertDetail" resultType="com.youlai.boot.modules.retail.model.vo.AlertVO">
+        SELECT
+            a.id,
+            a.store_id,
+            s.store_name,
+            a.product_id,
+            p.product_name,
+            p.product_code,
+            a.device_id,
+            a.lot_number,
+            a.alert_type,
+            a.priority,
+            a.status,
+            a.message,
+            a.threshold_value,
+            a.current_value,
+            a.detected_at,
+            a.acknowledged_at,
+            a.resolved_at,
+            a.closed_at,
+            a.resolution_note,
+            a.create_time,
+            a.update_time
+        FROM
+            retail_alert a
+        LEFT JOIN
+            retail_store s ON a.store_id = s.id
+        LEFT JOIN
+            retail_product p ON a.product_id = p.id
+        WHERE
+            a.id = #{id}
+    </select>
+
+    <!-- 在庫切れアラート対象取得 -->
+    <select id="findLowStockTargets" resultType="java.util.Map">
+        SELECT
+            i.store_id AS storeId,
+            i.product_id AS productId,
+            SUM(i.quantity) AS totalQuantity,
+            i.min_stock AS reorderPoint,
+            p.product_name AS productName,
+            s.store_name AS storeName
+        FROM
+            retail_inventory i
+        INNER JOIN
+            retail_product p ON i.product_id = p.id
+        INNER JOIN
+            retail_store s ON i.store_id = s.id
+        WHERE
+            i.quantity > 0
+            AND (i.expiry_date IS NULL OR i.expiry_date >= CURRENT_DATE)
+        GROUP BY
+            i.store_id, i.product_id, i.min_stock, p.product_name, s.store_name
+        HAVING
+            i.min_stock IS NOT NULL
+            AND i.min_stock > 0
+            AND SUM(i.quantity) &lt;= i.min_stock
+    </select>
+
+    <!-- 賞味期限接近アラート対象取得 -->
+    <select id="findExpirySoonTargets" resultType="java.util.Map">
+        SELECT
+            i.store_id AS storeId,
+            i.product_id AS productId,
+            i.lot_number AS lotNumber,
+            i.expiry_date AS expiryDate,
+            i.quantity AS quantity,
+            DATEDIFF(i.expiry_date, CURRENT_DATE) AS daysUntilExpiry,
+            p.product_name AS productName,
+            s.store_name AS storeName
+        FROM
+            retail_inventory i
+        INNER JOIN
+            retail_product p ON i.product_id = p.id
+        INNER JOIN
+            retail_store s ON i.store_id = s.id
+        WHERE
+            i.quantity > 0
+            AND i.expiry_date IS NOT NULL
+            AND i.expiry_date >= CURRENT_DATE
+            AND DATEDIFF(i.expiry_date, CURRENT_DATE) &lt;= 7
+        ORDER BY
+            i.expiry_date ASC
+    </select>
+
+    <!-- 在庫過多アラート対象取得 -->
+    <select id="findHighStockTargets" resultType="java.util.Map">
+        SELECT
+            i.store_id AS storeId,
+            i.product_id AS productId,
+            SUM(i.quantity) AS totalQuantity,
+            i.max_stock AS maxStock,
+            p.product_name AS productName,
+            s.store_name AS storeName
+        FROM
+            retail_inventory i
+        INNER JOIN
+            retail_product p ON i.product_id = p.id
+        INNER JOIN
+            retail_store s ON i.store_id = s.id
+        WHERE
+            i.quantity > 0
+            AND (i.expiry_date IS NULL OR i.expiry_date >= CURRENT_DATE)
+        GROUP BY
+            i.store_id, i.product_id, i.max_stock, p.product_name, s.store_name
+        HAVING
+            i.max_stock IS NOT NULL
+            AND i.max_stock > 0
+            AND SUM(i.quantity) >= i.max_stock * 1.5
+    </select>
+
+    <!-- 未解決アラートの存在チェック -->
+    <select id="existsUnresolvedAlert" resultType="boolean">
+        SELECT EXISTS(
+            SELECT 1 FROM retail_alert
+            WHERE store_id = #{storeId}
+            AND product_id = #{productId}
+            <if test="lotNumber != null and lotNumber != ''">
+                AND lot_number = #{lotNumber}
+            </if>
+            <if test="lotNumber == null or lotNumber == ''">
+                AND (lot_number IS NULL OR lot_number = '')
+            </if>
+            AND alert_type = #{alertType}
+            AND status NOT IN ('RESOLVED', 'CLOSED')
+        )
+    </select>
+
+</mapper>

--- a/backend/src/test/java/com/youlai/boot/modules/retail/controller/AlertControllerRestAssuredTest.java
+++ b/backend/src/test/java/com/youlai/boot/modules/retail/controller/AlertControllerRestAssuredTest.java
@@ -2,6 +2,7 @@ package com.youlai.boot.modules.retail.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
+import com.youlai.boot.modules.retail.model.form.AlertStatusForm;
 import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -129,6 +130,26 @@ public class AlertControllerRestAssuredTest {
     }
 
     @Test
+    void testGetAlertPageWithFilters() {
+        // ステータスフィルタ付きテスト
+        Response response = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .queryParam("pageNum", 1)
+            .queryParam("pageSize", 10)
+            .queryParam("status", "NEW")
+            .queryParam("priority", "P1")
+        .when()
+            .get(baseUrl + "/page");
+
+        prettyPrintJson("フィルタ付きアラート一覧取得レスポンス", response.getBody());
+
+        response.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+    }
+
+    @Test
     void testListAlerts() {
         // レスポンスデータを変数に格納
         Response response = given()
@@ -156,18 +177,19 @@ public class AlertControllerRestAssuredTest {
     }
 
     @Test
-    void testCreateAndUpdateAndDeleteAlert() {
-        // Create a new alert
+    void testCreateAndStatusTransitionAndDeleteAlert() {
+        // アラート作成
         AlertForm form = new AlertForm();
         form.setStoreId(1L);
         form.setProductId(1L);
         form.setLotNumber("TEST-LOT-001");
         form.setAlertType("LOW_STOCK");
-        form.setAlertMessage("テスト用アラート");
-        form.setAlertDate(LocalDateTime.now());
-        form.setResolved(false);
+        form.setPriority("P2");
+        form.setMessage("テスト用アラート - 在庫切れ警告");
+        form.setThresholdValue("10");
+        form.setCurrentValue("5");
+        form.setDetectedAt(LocalDateTime.now());
 
-        // Create alert - レスポンスデータを変数に格納
         Response createResponse = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
@@ -175,98 +197,110 @@ public class AlertControllerRestAssuredTest {
         .when()
             .post(baseUrl);
 
-        // レスポンスボディを変数に格納
-        ResponseBody createResponseBody = createResponse.getBody();
+        prettyPrintJson("アラート作成レスポンス", createResponse.getBody());
 
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラート作成レスポンス", createResponseBody);
-        System.out.println("ステータスコード: " + createResponse.getStatusCode());
-        System.out.println("レスポンスコード: " + createResponse.path("code"));
-
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_create", createResponseBody);
-
-        // レスポンスに対してアサーション
         createResponse.then()
             .statusCode(HttpStatus.OK.value())
-            .body("code", equalTo("00000"))
-            .body("msg", equalTo("一切ok"));
+            .body("code", equalTo("00000"));
 
-        // Get all alerts to find the newly created one
+        // 作成されたアラートのIDを取得
         Response listResponse = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
         .when()
             .get(baseUrl);
 
-        // レスポンスボディを変数に格納
-        ResponseBody listResponseBody = listResponse.getBody();
-
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラートリスト取得レスポンス", listResponseBody);
-
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_list_after_create", listResponseBody);
-
-        // 作成されたアラートのIDを取得
-        String alertId = listResponse.path("data.find { it.lotNumber == 'TEST-LOT-001' }.id");
+        String alertId = listResponse.path("data.find { it.lotNumber == 'TEST-LOT-001' }.id").toString();
         System.out.println("作成されたアラートID: " + alertId);
 
-        // Update the alert
-        form.setAlertMessage("更新されたテスト用アラート");
-
-        // アラート更新 - レスポンスデータを変数に格納
-        Response updateResponse = given()
-            .contentType(ContentType.JSON)
-            .header("Authorization", bearerToken)
-            .pathParam("id", alertId)
-            .body(form)
-        .when()
-            .put(baseUrl + "/{id}");
-
-        // レスポンスボディを変数に格納
-        ResponseBody updateResponseBody = updateResponse.getBody();
-
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラート更新レスポンス", updateResponseBody);
-        System.out.println("ステータスコード: " + updateResponse.getStatusCode());
-        System.out.println("レスポンスコード: " + updateResponse.path("code"));
-
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_update_" + alertId, updateResponseBody);
-
-        // レスポンスに対してアサーション
-        updateResponse.then()
-            .statusCode(HttpStatus.OK.value())
-            .body("code", equalTo("00000"))
-            .body("msg", equalTo("一切ok"));
-
-        // Resolve the alert
-        Response resolveResponse = given()
+        // アラート詳細取得
+        Response detailResponse = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
             .pathParam("id", alertId)
         .when()
-            .put(baseUrl + "/{id}/resolve");
+            .get(baseUrl + "/{id}");
 
-        // レスポンスボディを変数に格納
-        ResponseBody resolveResponseBody = resolveResponse.getBody();
+        prettyPrintJson("アラート詳細取得レスポンス", detailResponse.getBody());
 
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラート解決レスポンス", resolveResponseBody);
-        System.out.println("ステータスコード: " + resolveResponse.getStatusCode());
-        System.out.println("レスポンスコード: " + resolveResponse.path("code"));
-
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_resolve_" + alertId, resolveResponseBody);
-
-        // レスポンスに対してアサーション
-        resolveResponse.then()
+        detailResponse.then()
             .statusCode(HttpStatus.OK.value())
             .body("code", equalTo("00000"))
-            .body("msg", equalTo("一切ok"));
+            .body("data.alertType", equalTo("LOW_STOCK"))
+            .body("data.priority", equalTo("P2"))
+            .body("data.status", equalTo("NEW"));
 
-        // Delete the alert
+        // 状態遷移テスト: NEW -> ACK
+        AlertStatusForm ackForm = new AlertStatusForm();
+        ackForm.setStatus("ACK");
+
+        Response ackResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .pathParam("id", alertId)
+            .body(ackForm)
+        .when()
+            .put(baseUrl + "/{id}/status");
+
+        prettyPrintJson("アラート確認(ACK)レスポンス", ackResponse.getBody());
+
+        ackResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+
+        // 状態遷移テスト: ACK -> IN_PROGRESS
+        AlertStatusForm inProgressForm = new AlertStatusForm();
+        inProgressForm.setStatus("IN_PROGRESS");
+
+        Response inProgressResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .pathParam("id", alertId)
+            .body(inProgressForm)
+        .when()
+            .put(baseUrl + "/{id}/status");
+
+        prettyPrintJson("アラート対応開始(IN_PROGRESS)レスポンス", inProgressResponse.getBody());
+
+        inProgressResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+
+        // 状態遷移テスト: IN_PROGRESS -> RESOLVED
+        AlertStatusForm resolvedForm = new AlertStatusForm();
+        resolvedForm.setStatus("RESOLVED");
+        resolvedForm.setResolutionNote("在庫を補充しました。現在在庫: 50個");
+
+        Response resolvedResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .pathParam("id", alertId)
+            .body(resolvedForm)
+        .when()
+            .put(baseUrl + "/{id}/status");
+
+        prettyPrintJson("アラート解決(RESOLVED)レスポンス", resolvedResponse.getBody());
+
+        resolvedResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+
+        // 最終状態確認
+        Response finalDetailResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .pathParam("id", alertId)
+        .when()
+            .get(baseUrl + "/{id}");
+
+        prettyPrintJson("最終状態確認レスポンス", finalDetailResponse.getBody());
+
+        finalDetailResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.status", equalTo("RESOLVED"))
+            .body("data.resolutionNote", equalTo("在庫を補充しました。現在在庫: 50個"));
+
+        // クリーンアップ: アラート削除
         Response deleteResponse = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
@@ -274,20 +308,97 @@ public class AlertControllerRestAssuredTest {
         .when()
             .delete(baseUrl + "/{id}");
 
-        // レスポンスボディを変数に格納
-        ResponseBody deleteResponseBody = deleteResponse.getBody();
-
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラート削除レスポンス", deleteResponseBody);
-        System.out.println("ステータスコード: " + deleteResponse.getStatusCode());
-
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_delete_" + alertId, deleteResponseBody);
-
-        // レスポンスに対してアサーション
         deleteResponse.then()
             .statusCode(HttpStatus.OK.value())
-            .body("code", equalTo("00000"))
-            .body("msg", equalTo("一切ok"));
+            .body("code", equalTo("00000"));
+    }
+
+    @Test
+    void testCreateExpirySoonAlert() {
+        // 賞味期限接近アラート作成テスト
+        AlertForm form = new AlertForm();
+        form.setStoreId(1L);
+        form.setProductId(2L);
+        form.setLotNumber("LOT-2026-0209");
+        form.setAlertType("EXPIRY_SOON");
+        form.setPriority("P1");
+        form.setMessage("[賞味期限接近] 店舗: 東京本店, 商品: オーガニックティー, 賞味期限まで1日");
+        form.setThresholdValue("7");
+        form.setCurrentValue("1");
+        form.setDetectedAt(LocalDateTime.now());
+
+        Response createResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .body(form)
+        .when()
+            .post(baseUrl);
+
+        prettyPrintJson("賞味期限接近アラート作成レスポンス", createResponse.getBody());
+
+        createResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+
+        // クリーンアップ
+        Response listResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+        .when()
+            .get(baseUrl);
+
+        String alertId = listResponse.path("data.find { it.lotNumber == 'LOT-2026-0209' }.id").toString();
+
+        given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .pathParam("id", alertId)
+        .when()
+            .delete(baseUrl + "/{id}");
+    }
+
+    @Test
+    void testCreateHighStockAlert() {
+        // 在庫過多アラート作成テスト
+        AlertForm form = new AlertForm();
+        form.setStoreId(1L);
+        form.setProductId(3L);
+        form.setAlertType("HIGH_STOCK");
+        form.setPriority("P3");
+        form.setMessage("[在庫過多] 店舗: 名古屋栄店, 商品: ミネラルウォーター, 現在在庫: 150個, 適正上限: 100個");
+        form.setThresholdValue("150");
+        form.setCurrentValue("150");
+        form.setDetectedAt(LocalDateTime.now());
+
+        Response createResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+            .body(form)
+        .when()
+            .post(baseUrl);
+
+        prettyPrintJson("在庫過多アラート作成レスポンス", createResponse.getBody());
+
+        createResponse.then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo("00000"));
+
+        // クリーンアップ
+        Response listResponse = given()
+            .contentType(ContentType.JSON)
+            .header("Authorization", bearerToken)
+        .when()
+            .get(baseUrl);
+
+        String alertId = listResponse.path("data.find { it.alertType == 'HIGH_STOCK' && it.productId == 3 }.id").toString();
+
+        if (alertId != null && !alertId.equals("null")) {
+            given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", bearerToken)
+                .pathParam("id", alertId)
+            .when()
+                .delete(baseUrl + "/{id}");
+        }
     }
 }

--- a/backend/src/test/java/com/youlai/boot/modules/retail/controller/AlertControllerRestAssuredTest.java
+++ b/backend/src/test/java/com/youlai/boot/modules/retail/controller/AlertControllerRestAssuredTest.java
@@ -1,128 +1,43 @@
 package com.youlai.boot.modules.retail.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.youlai.boot.modules.retail.model.form.AlertForm;
 import com.youlai.boot.modules.retail.model.form.AlertStatusForm;
 import com.youlai.boot.modules.retail.model.query.AlertPageQuery;
-import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
-import io.restassured.response.ResponseBody;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class AlertControllerRestAssuredTest {
-
-    @LocalServerPort
-    private int port;
-
-    private String baseUrl;
-    private String bearerToken;
-    private ObjectMapper objectMapper = new ObjectMapper();
+public class AlertControllerRestAssuredTest extends BaseControllerTest {
 
     @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-        RestAssured.baseURI = "http://localhost";
-        baseUrl = "/api/v1/retail/alerts";
-
-        // 固定のトークンを使用
-        bearerToken = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiIsImRlcHRJZCI6MSwiZGF0YVNjb3BlIjowLCJleHAiOjE3NDY1ODcyNDgsInVzZXJJZCI6MiwiaWF0IjoxNzQ1OTgyNDQ4LCJhdXRob3JpdGllcyI6WyJST0xFX0FETUlOIl0sImp0aSI6IjU0MzQ2MWE5Y2NjMDQ2MjA5NWVmMzZmMWFlMGZiZDdiIn0.sN-EHmgOa7dIctxILX-cUSD1Sz-nn5HZ3xn2A5DO5AI";
-    }
-
-    /**
-     * JSONデータを整形して出力
-     */
-    private void prettyPrintJson(String title, ResponseBody body) {
-        try {
-            Object jsonObject = objectMapper.readValue(body.asString(), Object.class);
-            String prettyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
-            System.out.println(title + ":\n" + prettyJson);
-        } catch (Exception e) {
-            System.out.println(title + ": JSON整形エラー: " + e.getMessage());
-            System.out.println("生データ: " + body.asString());
-        }
-    }
-
-    /**
-     * レスポンスボディをJSONファイルとして保存する
-     */
-    private void saveResponseBodyAsJson(String urlPath, ResponseBody body) {
-        try {
-            // URLからホスト部分を削除
-            String cleanPath = urlPath;
-            // http://localhost:XXXXX/api/... のようなパターンを削除
-            if (urlPath.contains("://")) {
-                // URLからパス部分のみを抽出
-                int pathStartIndex = urlPath.indexOf("/", urlPath.indexOf("://") + 3);
-                if (pathStartIndex > 0) {
-                    cleanPath = urlPath.substring(pathStartIndex);
-                }
-            }
-
-            // ファイル名に使用できない文字を置換
-            String fileName = cleanPath.replaceAll("[\\/:*?\"<>|]", "_") + ".json";
-
-            // テストファイルと同じディレクトリにファイルを保存
-            Path directoryPath = Paths.get("src/test/java/com/youlai/boot/modules/retail/controller");
-            if (!Files.exists(directoryPath)) {
-                Files.createDirectories(directoryPath);
-            }
-
-            Path filePath = directoryPath.resolve(fileName);
-
-            // JSONデータを整形
-            Object jsonObject = objectMapper.readValue(body.asString(), Object.class);
-            String prettyJson = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(jsonObject);
-
-            // ファイルに書き込み
-            Files.writeString(filePath, prettyJson);
-            System.out.println("JSONファイルを保存しました: " + filePath.toAbsolutePath());
-        } catch (Exception e) {
-            System.out.println("JSONファイル保存エラー: " + e.getMessage());
-        }
+    @Override
+    protected void setUp() {
+        super.setUp();
+        baseUrl = "http://localhost:" + port + "/api/v1/retail/alerts";
     }
 
     @Test
     void testGetAlertPage() {
-        AlertPageQuery query = new AlertPageQuery();
-        query.setPageNum(1);
-        query.setPageSize(5);
-
-        // レスポンスデータを変数に格納
         Response response = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
-            .queryParam("pageNum", query.getPageNum())
-            .queryParam("pageSize", query.getPageSize())
+            .queryParam("pageNum", 1)
+            .queryParam("pageSize", 5)
         .when()
             .get(baseUrl + "/page");
 
-        // レスポンスボディを変数に格納
-        ResponseBody responseBody = response.getBody();
-
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラート一覧取得レスポンス", responseBody);
+        prettyPrintJson("アラート一覧取得レスポンス", response.getBody());
         System.out.println("ステータスコード: " + response.getStatusCode());
-        System.out.println("レスポンスコード: " + response.path("code"));
-        System.out.println("データ件数: " + response.path("data.total"));
 
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl + "_page", responseBody);
-
-        // レスポンスに対してアサーション
         response.then()
             .statusCode(HttpStatus.OK.value())
             .body("code", equalTo("00000"))
@@ -151,25 +66,15 @@ public class AlertControllerRestAssuredTest {
 
     @Test
     void testListAlerts() {
-        // レスポンスデータを変数に格納
         Response response = given()
             .contentType(ContentType.JSON)
             .header("Authorization", bearerToken)
         .when()
             .get(baseUrl);
 
-        // レスポンスボディを変数に格納
-        ResponseBody responseBody = response.getBody();
-
-        // レスポンスデータをJSONフォーマットでログ出力
-        prettyPrintJson("アラートリスト取得レスポンス", responseBody);
+        prettyPrintJson("アラートリスト取得レスポンス", response.getBody());
         System.out.println("ステータスコード: " + response.getStatusCode());
-        System.out.println("レスポンスコード: " + response.path("code"));
 
-        // レスポンスボディをJSONファイルとして保存
-        saveResponseBodyAsJson(baseUrl, responseBody);
-
-        // レスポンスに対してアサーション
         response.then()
             .statusCode(HttpStatus.OK.value())
             .body("code", equalTo("00000"))
@@ -316,10 +221,11 @@ public class AlertControllerRestAssuredTest {
     @Test
     void testCreateExpirySoonAlert() {
         // 賞味期限接近アラート作成テスト
+        String uniqueLotNumber = "EXPIRY-TEST-" + System.currentTimeMillis();
         AlertForm form = new AlertForm();
         form.setStoreId(1L);
         form.setProductId(2L);
-        form.setLotNumber("LOT-2026-0209");
+        form.setLotNumber(uniqueLotNumber);
         form.setAlertType("EXPIRY_SOON");
         form.setPriority("P1");
         form.setMessage("[賞味期限接近] 店舗: 東京本店, 商品: オーガニックティー, 賞味期限まで1日");
@@ -347,22 +253,26 @@ public class AlertControllerRestAssuredTest {
         .when()
             .get(baseUrl);
 
-        String alertId = listResponse.path("data.find { it.lotNumber == 'LOT-2026-0209' }.id").toString();
-
-        given()
-            .contentType(ContentType.JSON)
-            .header("Authorization", bearerToken)
-            .pathParam("id", alertId)
-        .when()
-            .delete(baseUrl + "/{id}");
+        Object alertIdObj = listResponse.path("data.find { it.lotNumber == '" + uniqueLotNumber + "' }.id");
+        if (alertIdObj != null) {
+            String alertId = alertIdObj.toString();
+            given()
+                .contentType(ContentType.JSON)
+                .header("Authorization", bearerToken)
+                .pathParam("id", alertId)
+            .when()
+                .delete(baseUrl + "/{id}");
+        }
     }
 
     @Test
     void testCreateHighStockAlert() {
         // 在庫過多アラート作成テスト
+        String uniqueLotNumber = "HIGH-STOCK-TEST-" + System.currentTimeMillis();
         AlertForm form = new AlertForm();
         form.setStoreId(1L);
         form.setProductId(3L);
+        form.setLotNumber(uniqueLotNumber);
         form.setAlertType("HIGH_STOCK");
         form.setPriority("P3");
         form.setMessage("[在庫過多] 店舗: 名古屋栄店, 商品: ミネラルウォーター, 現在在庫: 150個, 適正上限: 100個");
@@ -390,9 +300,9 @@ public class AlertControllerRestAssuredTest {
         .when()
             .get(baseUrl);
 
-        String alertId = listResponse.path("data.find { it.alertType == 'HIGH_STOCK' && it.productId == 3 }.id").toString();
-
-        if (alertId != null && !alertId.equals("null")) {
+        Object alertIdObj = listResponse.path("data.find { it.lotNumber == '" + uniqueLotNumber + "' }.id");
+        if (alertIdObj != null) {
+            String alertId = alertIdObj.toString();
             given()
                 .contentType(ContentType.JSON)
                 .header("Authorization", bearerToken)

--- a/backend/src/test/java/com/youlai/boot/modules/retail/controller/InventoryControllerRestAssuredTest.java
+++ b/backend/src/test/java/com/youlai/boot/modules/retail/controller/InventoryControllerRestAssuredTest.java
@@ -4,10 +4,14 @@ import com.youlai.boot.modules.retail.model.form.InventoryForm;
 import com.youlai.boot.modules.retail.model.form.InventoryReplenishForm;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
+import io.restassured.response.ResponseBody;
 import org.junit.jupiter.api.*;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
 
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;

--- a/backend/src/test/java/com/youlai/boot/modules/retail/controller/ProductControllerRestAssuredTest.java
+++ b/backend/src/test/java/com/youlai/boot/modules/retail/controller/ProductControllerRestAssuredTest.java
@@ -143,7 +143,8 @@ public class ProductControllerRestAssuredTest extends BaseControllerTest {
         form.setName("Test Product");
         form.setCode("TP001");
         form.setPrice(new BigDecimal("99.99"));
-        form.setStock(100);
+        form.setReorderPoint(10);
+        form.setMaxStockLevel(100);
         form.setCategoryId(1L);
         form.setCategoryName("Test Category");
         form.setDescription("Test Description");

--- a/backend/src/test/java/com/youlai/boot/modules/retail/controller/ProductControllerTest.java
+++ b/backend/src/test/java/com/youlai/boot/modules/retail/controller/ProductControllerTest.java
@@ -140,7 +140,8 @@ public class ProductControllerTest {
         form.setName("Test Product");
         form.setCode("TP001");
         form.setPrice(new BigDecimal("99.99"));
-        form.setStock(100);
+        form.setReorderPoint(10);
+        form.setMaxStockLevel(100);
         form.setCategoryId(1L);
         form.setCategoryName("Test Category");
         form.setDescription("Test Description");

--- a/docs/sql/retail_alert_update.sql
+++ b/docs/sql/retail_alert_update.sql
@@ -1,0 +1,41 @@
+-- アラートテーブル構造更新スクリプト
+-- Issue #15: [Phase 1 Backend] アラート管理機能
+
+-- 既存テーブルが存在する場合は削除して再作成
+DROP TABLE IF EXISTS retail_alert;
+
+-- アラートテーブル作成
+CREATE TABLE retail_alert (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT 'アラートID',
+    store_id BIGINT NOT NULL COMMENT '店舗ID',
+    product_id BIGINT COMMENT '商品ID',
+    device_id BIGINT COMMENT 'デバイスID',
+    lot_number VARCHAR(50) COMMENT 'ロット番号',
+    alert_type ENUM('LOW_STOCK', 'EXPIRY_SOON', 'HIGH_STOCK', 'COMMUNICATION_DOWN', 'PAYMENT_TERMINAL_DOWN') NOT NULL COMMENT 'アラートタイプ',
+    priority ENUM('P1', 'P2', 'P3', 'P4') NOT NULL COMMENT '優先度',
+    status ENUM('NEW', 'ACK', 'IN_PROGRESS', 'RESOLVED', 'CLOSED') DEFAULT 'NEW' COMMENT 'ステータス',
+    message VARCHAR(500) COMMENT 'アラートメッセージ',
+    threshold_value VARCHAR(50) COMMENT 'しきい値',
+    current_value VARCHAR(50) COMMENT '現在値',
+    detected_at DATETIME NOT NULL COMMENT '検知日時',
+    acknowledged_at DATETIME COMMENT '確認日時',
+    resolved_at DATETIME COMMENT '解決日時',
+    closed_at DATETIME COMMENT 'クローズ日時',
+    resolution_note TEXT COMMENT '解決メモ',
+    create_time DATETIME DEFAULT CURRENT_TIMESTAMP COMMENT '作成日時',
+    update_time DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新日時',
+    KEY idx_alert_store_status (store_id, status, detected_at),
+    KEY idx_alert_type_priority (alert_type, priority),
+    CONSTRAINT fk_alert_store FOREIGN KEY (store_id) REFERENCES retail_store(id),
+    CONSTRAINT fk_alert_product FOREIGN KEY (product_id) REFERENCES retail_product(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='アラート';
+
+-- インデックス追加
+CREATE INDEX idx_alert_detected_at ON retail_alert(detected_at);
+CREATE INDEX idx_alert_status ON retail_alert(status);
+
+-- サンプルデータ挿入（テスト用）
+INSERT INTO retail_alert (store_id, product_id, lot_number, alert_type, priority, status, message, threshold_value, current_value, detected_at) VALUES
+(1, 1, NULL, 'LOW_STOCK', 'P1', 'NEW', '[在庫切れ警告] 店舗: 東京本店, 商品: プレミアムコーヒー, 現在在庫: 2個, 発注点: 10個', '10', '2', NOW()),
+(1, 2, 'LOT-2026-0201', 'EXPIRY_SOON', 'P2', 'NEW', '[賞味期限接近] 店舗: 東京本店, 商品: オーガニックティー, ロット: LOT-2026-0201, 賞味期限まで3日', '7', '3', NOW()),
+(2, 3, NULL, 'HIGH_STOCK', 'P3', 'NEW', '[在庫過多] 店舗: 横浜駅前店, 商品: ミネラルウォーター, 現在在庫: 150個, 適正上限: 100個', '150', '150', NOW());


### PR DESCRIPTION
## Summary
- Alert CRUD API実装 (`/api/v1/retail/alerts`)
- ステータス更新API (`PUT /api/v1/retail/alerts/{id}/status`)
- アラート検知バッチ処理 (xxl-job対応)
- ページング・フィルタ・ソート機能
- RestAssured E2Eテスト (6件全て成功)

## 主な変更
- Alert エンティティ: ステータスワークフロー対応 (NEW → ACK → IN_PROGRESS → RESOLVED → CLOSED)
- 優先度: P1(緊急), P2(高), P3(中), P4(低)
- アラートタイプ: LOW_STOCK, EXPIRY_SOON, HIGH_STOCK
- 検知ロジック: 在庫切れ、賞味期限接近、在庫過多の自動検知

## Test plan
- [x] AlertControllerRestAssuredTest: 6/6 成功
- [x] ビルド成功確認

Closes #15