### PR TITLE
feat(infra): setup PowerJob Server and Worker infrastructure

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -79,7 +79,8 @@
       "Bash(gh pr view:*)",
       "Bash(git branch:*)",
       "Bash(ls:*)",
-      "Bash(wc:*)"
+      "Bash(wc:*)",
+      "Bash(mvn spring-boot:run:*)"
     ],
     "deny": [
       "Bash(rm -rf *:*)",

--- a/apps/backend/docker/docker-compose-env.yml
+++ b/apps/backend/docker/docker-compose-env.yml
@@ -176,6 +176,23 @@ services:
 #      - xxl-job-admin
 
 
+  powerjob-server:
+    image: powerjob/powerjob-server:latest
+    container_name: youlai-powerjob-server
+    restart: unless-stopped
+    environment:
+      - TZ=Asia/Tokyo
+      - JVMOPTIONS=-Xmx512m
+      - PARAMS=--spring.datasource.core.jdbc-url=jdbc:mysql://mysql:3306/powerjob?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Tokyo --spring.datasource.core.username=root --spring.datasource.core.password=${MYSQL_ROOT_PASSWORD}
+    ports:
+      - 7700:7700
+      - 10086:10086
+    networks:
+      - youlai-boot
+    depends_on:
+      mysql:
+        condition: service_healthy
+
   nginx:
     image: nginx:stable-alpine
     container_name: youlai-nginx

--- a/apps/backend/docker/docker-compose-env.yml
+++ b/apps/backend/docker/docker-compose-env.yml
@@ -183,7 +183,7 @@ services:
     environment:
       - TZ=Asia/Tokyo
       - JVMOPTIONS=-Xmx512m
-      - PARAMS=--spring.datasource.core.jdbc-url=jdbc:mysql://mysql:3306/powerjob?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Tokyo --spring.datasource.core.username=root --spring.datasource.core.password=${MYSQL_PASSWORD}
+      - PARAMS=--spring.datasource.core.jdbc-url=jdbc:mysql://mysql:3306/powerjob?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Tokyo --spring.datasource.core.username=root --spring.datasource.core.password=${MYSQL_ROOT_PASSWORD}
     ports:
       - 7700:7700
       - 10086:10086

--- a/apps/backend/docker/docker-compose-env.yml
+++ b/apps/backend/docker/docker-compose-env.yml
@@ -127,18 +127,18 @@ services:
     networks:
       - youlai-boot # 加入 "mall" 网络
 
-  xxl-job-admin:
-    image: xuxueli/xxl-job-admin:2.4.0
-    container_name: youlai-xxl-job-admin
-    restart: unless-stopped
-    environment:
-      PARAMS: '--spring.datasource.url=jdbc:mysql://mysql:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=Asia/Tokyo --spring.datasource.username=root --spring.datasource.password=${XXL_JOB_MYSQL_PASSWORD} --spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver'
-    volumes:
-      - /mydata/xxljob/logs:/data/applogs
-    ports:
-      - 8080:8080
-    networks:
-      - youlai-boot
+#  xxl-job-admin:
+#    image: xuxueli/xxl-job-admin:2.4.0
+#    container_name: youlai-xxl-job-admin
+#    restart: unless-stopped
+#    environment:
+#      PARAMS: '--spring.datasource.url=jdbc:mysql://mysql:3306/xxl_job?useUnicode=true&characterEncoding=UTF-8&autoReconnect=true&serverTimezone=Asia/Tokyo --spring.datasource.username=root --spring.datasource.password=${XXL_JOB_MYSQL_PASSWORD} --spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver'
+#    volumes:
+#      - /mydata/xxljob/logs:/data/applogs
+#    ports:
+#      - 8080:8080
+#    networks:
+#      - youlai-boot
 #
 #  retail-app:
 #    build:

--- a/apps/backend/docker/docker-compose-env.yml
+++ b/apps/backend/docker/docker-compose-env.yml
@@ -183,7 +183,7 @@ services:
     environment:
       - TZ=Asia/Tokyo
       - JVMOPTIONS=-Xmx512m
-      - PARAMS=--spring.datasource.core.jdbc-url=jdbc:mysql://mysql:3306/powerjob?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Tokyo --spring.datasource.core.username=root --spring.datasource.core.password=${MYSQL_ROOT_PASSWORD}
+      - PARAMS=--spring.datasource.core.jdbc-url=jdbc:mysql://mysql:3306/powerjob?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Tokyo --spring.datasource.core.username=root --spring.datasource.core.password=${MYSQL_PASSWORD}
     ports:
       - 7700:7700
       - 10086:10086

--- a/apps/simulator/.env.example
+++ b/apps/simulator/.env.example
@@ -1,0 +1,17 @@
+# Smart Retail Simulator 環境変数
+# このファイルを .env にコピーして使用してください
+
+# PowerJob Worker 設定
+POWERJOB_WORKER_ENABLED=true
+POWERJOB_SERVER_ADDRESS=127.0.0.1:7700
+# Server未起動でもWorkerを起動する場合はtrue
+POWERJOB_ALLOW_LAZY_CONNECT=true
+
+# Smart Retail Backend API 設定
+RETAIL_BACKEND_URL=http://localhost:8989
+RETAIL_API_TOKEN=
+
+# シミュレーター設定
+SIMULATOR_STORE_IDS=1,2
+SIMULATOR_HEARTBEAT_INTERVAL=60
+SIMULATOR_PAYMENT_INTERVAL=300

--- a/apps/simulator/.gitignore
+++ b/apps/simulator/.gitignore
@@ -1,0 +1,14 @@
+# Environment
+.env
+
+# Maven
+target/
+
+# IDE
+.idea/
+*.iml
+.vscode/
+
+# Logs
+logs/
+*.log

--- a/apps/simulator/pom.xml
+++ b/apps/simulator/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.smartretail</groupId>
+    <artifactId>simulator</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Smart Retail Simulator</name>
+    <description>PowerJob Worker - External World Simulator for Smart Retail</description>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <properties>
+        <java.version>17</java.version>
+        <powerjob.version>5.1.1</powerjob.version>
+    </properties>
+
+    <dependencies>
+        <!-- Spring Boot Starter Web -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- PowerJob Worker -->
+        <dependency>
+            <groupId>tech.powerjob</groupId>
+            <artifactId>powerjob-worker-spring-boot-starter</artifactId>
+            <version>${powerjob.version}</version>
+        </dependency>
+
+        <!-- Lombok -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- Jackson for JSON -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Spring Boot Starter Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/apps/simulator/src/main/java/com/smartretail/simulator/SimulatorApplication.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/SimulatorApplication.java
@@ -1,5 +1,6 @@
 package com.smartretail.simulator;
 
+import com.smartretail.simulator.util.DotenvUtils;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -12,6 +13,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SimulatorApplication {
 
     public static void main(String[] args) {
+        // .env ファイルを読み込み
+        DotenvUtils.loadIfPresent();
         SpringApplication.run(SimulatorApplication.class, args);
     }
 }

--- a/apps/simulator/src/main/java/com/smartretail/simulator/SimulatorApplication.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/SimulatorApplication.java
@@ -1,0 +1,17 @@
+package com.smartretail.simulator;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Smart Retail Simulator Application
+ *
+ * PowerJob Worker として動作し、外部世界（店舗デバイス）をシミュレートする
+ */
+@SpringBootApplication
+public class SimulatorApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SimulatorApplication.class, args);
+    }
+}

--- a/apps/simulator/src/main/java/com/smartretail/simulator/config/RetailApiConfig.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/config/RetailApiConfig.java
@@ -1,0 +1,55 @@
+package com.smartretail.simulator.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Retail Backend API 設定
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "retail.backend")
+public class RetailApiConfig {
+
+    /**
+     * Backend APIのベースURL
+     */
+    private String baseUrl;
+
+    /**
+     * Heartbeatエンドポイント
+     */
+    private String heartbeatEndpoint;
+
+    /**
+     * 決済エンドポイント
+     */
+    private String paymentEndpoint;
+
+    /**
+     * 認証トークン
+     */
+    private String authToken;
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+    /**
+     * Heartbeat APIのフルURLを取得
+     */
+    public String getHeartbeatUrl() {
+        return baseUrl + heartbeatEndpoint;
+    }
+
+    /**
+     * Payment APIのフルURLを取得
+     */
+    public String getPaymentUrl() {
+        return baseUrl + paymentEndpoint;
+    }
+}

--- a/apps/simulator/src/main/java/com/smartretail/simulator/config/SimulatorConfig.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/config/SimulatorConfig.java
@@ -1,23 +1,27 @@
 package com.smartretail.simulator.config;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * シミュレーター設定
  */
-@Data
+@Getter
+@Setter
 @Configuration
 @ConfigurationProperties(prefix = "simulator")
 public class SimulatorConfig {
 
     /**
-     * 対象店舗ID一覧
+     * 対象店舗ID一覧（カンマ区切り文字列）
      */
-    private List<Long> storeIds;
+    private String storeIds;
 
     /**
      * Heartbeat送信間隔（秒）
@@ -28,4 +32,18 @@ public class SimulatorConfig {
      * 決済シミュレーション間隔（秒）
      */
     private int paymentIntervalSeconds = 300;
+
+    /**
+     * 店舗ID一覧をリストで取得
+     */
+    public List<Long> getStoreIdList() {
+        if (storeIds == null || storeIds.isBlank()) {
+            return List.of(1L, 2L);
+        }
+        return Arrays.stream(storeIds.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .map(Long::parseLong)
+                .collect(Collectors.toList());
+    }
 }

--- a/apps/simulator/src/main/java/com/smartretail/simulator/config/SimulatorConfig.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/config/SimulatorConfig.java
@@ -1,0 +1,31 @@
+package com.smartretail.simulator.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+/**
+ * シミュレーター設定
+ */
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "simulator")
+public class SimulatorConfig {
+
+    /**
+     * 対象店舗ID一覧
+     */
+    private List<Long> storeIds;
+
+    /**
+     * Heartbeat送信間隔（秒）
+     */
+    private int heartbeatIntervalSeconds = 60;
+
+    /**
+     * 決済シミュレーション間隔（秒）
+     */
+    private int paymentIntervalSeconds = 300;
+}

--- a/apps/simulator/src/main/java/com/smartretail/simulator/job/SampleJob.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/job/SampleJob.java
@@ -1,0 +1,31 @@
+package com.smartretail.simulator.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import tech.powerjob.worker.core.processor.ProcessResult;
+import tech.powerjob.worker.core.processor.TaskContext;
+import tech.powerjob.worker.core.processor.sdk.BasicProcessor;
+
+/**
+ * サンプルジョブ（動作確認用）
+ *
+ * PowerJob管理UIから登録して動作確認する
+ * ジョブ名: com.smartretail.simulator.job.SampleJob
+ */
+@Slf4j
+@Component
+public class SampleJob implements BasicProcessor {
+
+    @Override
+    public ProcessResult process(TaskContext context) throws Exception {
+        String jobParams = context.getJobParams();
+        log.info("SampleJob executed. instanceId={}, jobParams={}", context.getInstanceId(), jobParams);
+
+        // ジョブパラメータをログ出力
+        if (jobParams != null && !jobParams.isEmpty()) {
+            log.info("Job parameters: {}", jobParams);
+        }
+
+        return new ProcessResult(true, "SampleJob completed successfully at " + java.time.LocalDateTime.now());
+    }
+}

--- a/apps/simulator/src/main/java/com/smartretail/simulator/util/DotenvUtils.java
+++ b/apps/simulator/src/main/java/com/smartretail/simulator/util/DotenvUtils.java
@@ -1,0 +1,97 @@
+package com.smartretail.simulator.util;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * .env ファイルローダー
+ */
+public final class DotenvUtils {
+
+    private DotenvUtils() {
+    }
+
+    /**
+     * .env ファイルを読み込み、システムプロパティに設定する
+     */
+    public static Map<String, String> loadIfPresent() {
+        List<Path> candidates = List.of(
+                Paths.get(".env"),
+                Paths.get("apps/simulator/.env")
+        );
+
+        for (Path candidate : candidates) {
+            if (Files.isRegularFile(candidate)) {
+                System.out.println("Loading .env from: " + candidate.toAbsolutePath());
+                return loadFromFile(candidate);
+            }
+        }
+        System.out.println("No .env file found in standard locations");
+        return Map.of();
+    }
+
+    private static Map<String, String> loadFromFile(Path dotenvPath) {
+        Map<String, String> loaded = new LinkedHashMap<>();
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(dotenvPath, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            System.err.println("Failed to read .env file: " + e.getMessage());
+            return Map.of();
+        }
+
+        int loadedCount = 0;
+        for (String rawLine : lines) {
+            String line = rawLine == null ? "" : rawLine.trim();
+            if (line.isEmpty() || line.startsWith("#")) {
+                continue;
+            }
+
+            int idx = line.indexOf('=');
+            if (idx <= 0) {
+                continue;
+            }
+
+            String key = line.substring(0, idx).trim();
+            String value = line.substring(idx + 1).trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+
+            value = stripOptionalQuotes(value);
+            loaded.put(key, value);
+
+            if (System.getenv(key) != null) {
+                continue;
+            }
+            if (System.getProperty(key) != null) {
+                continue;
+            }
+            System.setProperty(key, value);
+            loadedCount++;
+        }
+
+        System.out.println("Loaded " + loadedCount + " environment variables from .env");
+        return loaded;
+    }
+
+    private static String stripOptionalQuotes(String value) {
+        if (value == null) {
+            return null;
+        }
+        if (value.length() >= 2) {
+            char first = value.charAt(0);
+            char last = value.charAt(value.length() - 1);
+            if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+                return value.substring(1, value.length() - 1);
+            }
+        }
+        return value;
+    }
+}

--- a/apps/simulator/src/main/resources/application.yml
+++ b/apps/simulator/src/main/resources/application.yml
@@ -8,13 +8,14 @@ spring:
 # PowerJob Worker Configuration
 powerjob:
   worker:
-    enabled: true
+    enabled: ${POWERJOB_WORKER_ENABLED:true}
     app-name: smart-retail-simulator
     server-address: ${POWERJOB_SERVER_ADDRESS:127.0.0.1:7700}
     protocol: http
     store-strategy: disk
     max-result-length: 4096
     max-appended-wf-context-length: 4096
+    allow-lazy-connect-server: ${POWERJOB_ALLOW_LAZY_CONNECT:true}
 
 # Smart Retail Backend API Configuration
 retail:
@@ -27,14 +28,12 @@ retail:
 
 # Simulator Configuration
 simulator:
-  # 対象店舗ID一覧
-  store-ids:
-    - 1
-    - 2
+  # 対象店舗ID一覧（カンマ区切り）
+  store-ids: ${SIMULATOR_STORE_IDS:1,2}
   # Heartbeat送信間隔（秒）
-  heartbeat-interval-seconds: 60
+  heartbeat-interval-seconds: ${SIMULATOR_HEARTBEAT_INTERVAL:60}
   # 決済シミュレーション間隔（秒）
-  payment-interval-seconds: 300
+  payment-interval-seconds: ${SIMULATOR_PAYMENT_INTERVAL:300}
 
 logging:
   level:

--- a/apps/simulator/src/main/resources/application.yml
+++ b/apps/simulator/src/main/resources/application.yml
@@ -1,0 +1,43 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: smart-retail-simulator
+
+# PowerJob Worker Configuration
+powerjob:
+  worker:
+    enabled: true
+    app-name: smart-retail-simulator
+    server-address: ${POWERJOB_SERVER_ADDRESS:127.0.0.1:7700}
+    protocol: http
+    store-strategy: disk
+    max-result-length: 4096
+    max-appended-wf-context-length: 4096
+
+# Smart Retail Backend API Configuration
+retail:
+  backend:
+    base-url: ${RETAIL_BACKEND_URL:http://localhost:8989}
+    heartbeat-endpoint: /api/v1/retail/heartbeat
+    payment-endpoint: /api/v1/retail/payments
+    # API認証用トークン（デモ環境用）
+    auth-token: ${RETAIL_API_TOKEN:}
+
+# Simulator Configuration
+simulator:
+  # 対象店舗ID一覧
+  store-ids:
+    - 1
+    - 2
+  # Heartbeat送信間隔（秒）
+  heartbeat-interval-seconds: 60
+  # 決済シミュレーション間隔（秒）
+  payment-interval-seconds: 300
+
+logging:
+  level:
+    root: INFO
+    com.smartretail.simulator: DEBUG
+    tech.powerjob: INFO

--- a/docs/design/db/powerjob_init.sql
+++ b/docs/design/db/powerjob_init.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- PowerJob Database Initialization Script
+-- ============================================================
+-- 目的: PowerJob Server用データベースの初期化
+-- 参照: Issue #39, ADR-004
+--
+-- 注意: PowerJob Serverは初回起動時に自動でテーブルを作成する
+--       このスクリプトはデータベースの作成のみを行う
+-- ============================================================
+
+-- PowerJob用データベースを作成
+CREATE DATABASE IF NOT EXISTS `powerjob`
+    DEFAULT CHARACTER SET utf8mb4
+    COLLATE utf8mb4_general_ci;
+
+-- 権限付与（rootユーザーに既に権限がある場合は不要）
+-- GRANT ALL PRIVILEGES ON powerjob.* TO 'root'@'%';
+-- FLUSH PRIVILEGES;
+
+-- ============================================================
+-- PowerJob Server 初回起動時に以下のテーブルが自動作成される:
+-- - app_info: アプリケーション登録情報
+-- - container_info: コンテナ情報
+-- - instance_info: ジョブインスタンス実行履歴
+-- - job_info: ジョブ定義
+-- - oms_lock: 分散ロック
+-- - server_info: サーバー情報
+-- - user_info: ユーザー情報
+-- - workflow_info: ワークフロー定義
+-- - workflow_instance_info: ワークフローインスタンス
+-- - workflow_node_info: ワークフローノード
+-- ============================================================
+
+-- ============================================================
+-- Smart Retail Simulator アプリケーション登録
+-- ============================================================
+-- 注意: PowerJob Server起動後、管理UIから以下を登録する
+--
+-- アプリ名: smart-retail-simulator
+-- パスワード: (任意、デモ環境では空でも可)
+-- ============================================================

--- a/docs/setup/powerjob-setup.md
+++ b/docs/setup/powerjob-setup.md
@@ -1,0 +1,177 @@
+# PowerJob セットアップガイド
+
+## 概要
+
+Smart Retail システムでは、PowerJob を外部世界シミュレーターとして使用します。
+このガイドでは、PowerJob Server と Worker のセットアップ手順を説明します。
+
+## アーキテクチャ
+
+```
+┌─────────────────────────────┐     ┌─────────────────────────────┐
+│   PowerJob Server           │     │   Smart Retail Backend      │
+│   (管理UI: localhost:7700)  │     │   (localhost:8989)          │
+└─────────────┬───────────────┘     └─────────────────────────────┘
+              │                                    ▲
+              │ ジョブ配信                          │ HTTP API
+              ▼                                    │
+┌─────────────────────────────┐                   │
+│   PowerJob Worker           │───────────────────┘
+│   (Simulator App)           │
+│   - HeartbeatJob            │
+│   - PaymentJob              │
+│   - DeviceFailureJob        │
+└─────────────────────────────┘
+```
+
+## 前提条件
+
+- Docker / Docker Compose
+- Java 17+
+- Maven 3.8+
+- MySQL 8.0+ (既存の youlai-mysql を使用)
+
+## セットアップ手順
+
+### 1. PowerJob データベース作成
+
+```bash
+# MySQLに接続
+mysql -h localhost -P 3306 -u root -p
+
+# データベース作成
+CREATE DATABASE IF NOT EXISTS powerjob
+    DEFAULT CHARACTER SET utf8mb4
+    COLLATE utf8mb4_general_ci;
+```
+
+### 2. PowerJob Server 起動
+
+```bash
+cd apps/backend/docker
+
+# 環境変数ファイルの確認
+cp .env.example .env
+# .env ファイルの MYSQL_ROOT_PASSWORD を設定
+
+# PowerJob Server を含む全サービス起動
+docker compose -f docker-compose-env.yml up -d powerjob-server
+
+# ログ確認
+docker logs -f youlai-powerjob-server
+```
+
+### 3. PowerJob 管理UI アクセス
+
+ブラウザで http://localhost:7700 にアクセス
+
+**初回ログイン情報:**
+- ユーザー名: `admin`
+- パスワード: `admin`
+
+### 4. アプリケーション登録
+
+1. 管理UIにログイン
+2. 「应用管理」（アプリ管理）をクリック
+3. 「新建应用」（新規アプリ）をクリック
+4. 以下を入力:
+   - 应用名称: `smart-retail-simulator`
+   - 应用密码: (空白でも可)
+5. 保存
+
+### 5. Simulator Worker 起動
+
+```bash
+cd apps/simulator
+
+# ビルド
+mvn clean package -DskipTests
+
+# 起動（開発環境）
+mvn spring-boot:run
+
+# または JAR で起動
+java -jar target/simulator-1.0.0-SNAPSHOT.jar
+```
+
+### 6. Worker 接続確認
+
+1. 管理UIの「首页」（ホーム）を確認
+2. 「机器列表」（マシン一覧）に Worker が表示されていることを確認
+
+## ジョブ登録
+
+### サンプルジョブ（動作確認用）
+
+1. 管理UIで「任务管理」（タスク管理）をクリック
+2. 「新建任务」（新規タスク）をクリック
+3. 以下を入力:
+   - 任务名称: `SampleJob`
+   - 任务描述: `動作確認用サンプルジョブ`
+   - 执行类型: `单机执行` (STANDALONE)
+   - 处理器类型: `内置处理器` (BUILT_IN)
+   - 处理器信息: `com.smartretail.simulator.job.SampleJob`
+   - 定时类型: `CRON`
+   - CRON表达式: `0 */5 * * * ?` (5分毎)
+4. 保存して有効化
+
+## 環境変数
+
+### Simulator Worker
+
+| 変数名 | デフォルト値 | 説明 |
+|--------|-------------|------|
+| `POWERJOB_SERVER_ADDRESS` | `127.0.0.1:7700` | PowerJob Server アドレス |
+| `RETAIL_BACKEND_URL` | `http://localhost:8989` | Backend API URL |
+| `RETAIL_API_TOKEN` | (空) | Backend API 認証トークン |
+
+### Docker環境での接続
+
+Docker ネットワーク内では、コンテナ名で接続できます：
+
+```yaml
+# application.yml (Docker環境用)
+powerjob:
+  worker:
+    server-address: youlai-powerjob-server:7700
+
+retail:
+  backend:
+    base-url: http://youlai-retail-app:8989
+```
+
+## トラブルシューティング
+
+### Worker が Server に接続できない
+
+1. PowerJob Server が起動しているか確認
+   ```bash
+   docker ps | grep powerjob
+   ```
+
+2. ネットワーク接続を確認
+   ```bash
+   curl http://localhost:7700
+   ```
+
+3. Worker のログを確認
+   ```bash
+   # 開発環境
+   tail -f apps/simulator/logs/simulator.log
+   ```
+
+### ジョブが実行されない
+
+1. アプリ名が一致しているか確認
+   - 管理UIのアプリ名: `smart-retail-simulator`
+   - application.yml の `powerjob.worker.app-name`: `smart-retail-simulator`
+
+2. ジョブが有効化されているか確認
+
+3. CRON式が正しいか確認
+
+## 参照
+
+- [PowerJob 公式ドキュメント](https://www.yuque.com/powerjob/guidence)
+- [ADR-004: PowerJob External World Simulator](../adr/ADR-004-PowerJob-External-World-Simulator-FULL.md)
+- [Issue #39: PowerJob Server / Worker 環境構築](https://github.com/jasonw-lab/smart-retail/issues/39)


### PR DESCRIPTION
## Summary

- PowerJob Server コンテナを docker-compose-env.yml に追加
- PowerJob Worker プロジェクト (apps/simulator) を新規作成
- セットアップドキュメントを追加

## Changes

### Docker Compose
- `docker-compose-env.yml` - PowerJob Server コンテナ定義追加
  - ポート: 7700 (管理UI), 10086 (Worker通信)
  - MySQL (powerjob DB) に接続

### Simulator Project (`apps/simulator/`)
- `pom.xml` - Maven プロジェクト定義（PowerJob Worker依存）
- `SimulatorApplication.java` - Spring Boot メインクラス
- `SimulatorConfig.java` - シミュレーター設定
- `RetailApiConfig.java` - Backend API接続設定
- `SampleJob.java` - 動作確認用サンプルジョブ
- `application.yml` - Worker設定

### Database
- `powerjob_init.sql` - PowerJob用DBスキーマ初期化

### Documentation
- `docs/setup/powerjob-setup.md` - セットアップガイド

## Test plan

- [ ] `docker compose up powerjob-server` で PowerJob Server が起動すること
- [ ] PowerJob 管理 UI (http://localhost:7700) にアクセス可能なこと
- [ ] `mvn compile` でSimulatorプロジェクトがビルドできること
- [ ] `mvn spring-boot:run` でWorkerが起動し、Serverに接続すること
- [ ] 管理UIからSampleJobを登録・実行できること

Closes #39