### PR TITLE
feat(device): add Device List API for DV-01 (issue-49)

### DIFF
--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/controller/DeviceController.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/controller/DeviceController.java
@@ -1,0 +1,74 @@
+package com.youlai.boot.modules.retail.controller;
+
+import com.youlai.boot.common.result.PageResult;
+import com.youlai.boot.common.result.Result;
+import com.youlai.boot.modules.retail.model.entity.Device;
+import com.youlai.boot.modules.retail.model.form.DeviceForm;
+import com.youlai.boot.modules.retail.model.query.DevicePageQuery;
+import com.youlai.boot.modules.retail.model.vo.DevicePageVO;
+import com.youlai.boot.modules.retail.service.DeviceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * デバイス管理API
+ *
+ * @author jason.w
+ */
+@Tag(name = "デバイス管理API")
+@RestController
+@RequestMapping("/api/v1/retail/devices")
+@RequiredArgsConstructor
+public class DeviceController {
+
+    private final DeviceService deviceService;
+
+    @Operation(summary = "デバイス一覧（ページング）")
+    @GetMapping("/page")
+    public PageResult<DevicePageVO> getDevicePage(@Valid DevicePageQuery queryParams) {
+        return deviceService.getDevicePage(queryParams);
+    }
+
+    @Operation(summary = "デバイス一覧（全件）")
+    @GetMapping
+    public Result<List<Device>> listDevices() {
+        return Result.success(deviceService.listDevices());
+    }
+
+    @Operation(summary = "店舗別デバイス一覧")
+    @GetMapping("/store/{storeId}")
+    public Result<List<Device>> listDevicesByStoreId(
+            @Parameter(description = "店舗ID") @PathVariable Long storeId) {
+        return Result.success(deviceService.listDevicesByStoreId(storeId));
+    }
+
+    @Operation(summary = "デバイス詳細取得")
+    @GetMapping("/{id}")
+    public Result<Device> getDevice(@PathVariable Long id) {
+        return Result.success(deviceService.getDeviceById(id));
+    }
+
+    @Operation(summary = "デバイス新規作成")
+    @PostMapping
+    public Result<?> createDevice(@RequestBody @Valid DeviceForm form) {
+        return Result.judge(deviceService.createDevice(form));
+    }
+
+    @Operation(summary = "デバイス更新")
+    @PutMapping("/{id}")
+    public Result<?> updateDevice(@PathVariable Long id, @RequestBody @Valid DeviceForm form) {
+        return Result.judge(deviceService.updateDevice(id, form));
+    }
+
+    @Operation(summary = "デバイス削除")
+    @DeleteMapping("/{id}")
+    public Result<?> deleteDevice(@PathVariable Long id) {
+        return Result.judge(deviceService.deleteDevice(id));
+    }
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/converter/DeviceConverter.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/converter/DeviceConverter.java
@@ -1,0 +1,35 @@
+package com.youlai.boot.modules.retail.converter;
+
+import com.youlai.boot.modules.retail.model.entity.Device;
+import com.youlai.boot.modules.retail.model.form.DeviceForm;
+import com.youlai.boot.modules.retail.model.vo.DevicePageVO;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+
+/**
+ * デバイスコンバーター
+ *
+ * @author jason.w
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface DeviceConverter {
+
+    /**
+     * DeviceForm から Device エンティティへの変換
+     *
+     * @param form デバイスフォーム
+     * @return デバイスエンティティ
+     */
+    @Mapping(target = "id", ignore = true)
+    Device form2Entity(DeviceForm form);
+
+    /**
+     * Device エンティティから DevicePageVO への変換
+     *
+     * @param entity デバイスエンティティ
+     * @return デバイスページングVO
+     */
+    @Mapping(target = "storeName", ignore = true)
+    DevicePageVO entity2Vo(Device entity);
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/form/DeviceForm.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/form/DeviceForm.java
@@ -1,0 +1,52 @@
+package com.youlai.boot.modules.retail.model.form;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * デバイスフォーム
+ *
+ * @author jason.w
+ */
+@Schema(description = "デバイスフォーム")
+@Data
+public class DeviceForm {
+
+    @Schema(description = "デバイスID（更新時にフロントが送る場合あり。サーバー側ではPathVariableのIDを優先）")
+    private Long id;
+
+    @Schema(description = "店舗ID", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "店舗IDは必須です")
+    private Long storeId;
+
+    @Schema(description = "デバイスコード（自動採番も可能）")
+    @Size(max = 50, message = "デバイスコードは50文字以内で入力してください")
+    private String deviceCode;
+
+    @Schema(description = "デバイスタイプ", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "デバイスタイプは必須です")
+    private String deviceType;
+
+    @Schema(description = "デバイス名", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "デバイス名は必須です")
+    @Size(max = 100, message = "デバイス名は100文字以内で入力してください")
+    private String deviceName;
+
+    @Schema(description = "ステータス（ONLINE, OFFLINE, ERROR, MAINTENANCE）")
+    private String status;
+
+    @Schema(description = "最終Heartbeat受信日時")
+    private LocalDateTime lastHeartbeat;
+
+    @Schema(description = "エラーコード")
+    @Size(max = 50, message = "エラーコードは50文字以内で入力してください")
+    private String errorCode;
+
+    @Schema(description = "デバイス固有情報（JSON）")
+    private String metadata;
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/query/DevicePageQuery.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/query/DevicePageQuery.java
@@ -1,0 +1,32 @@
+package com.youlai.boot.modules.retail.model.query;
+
+import com.youlai.boot.common.base.BasePageQuery;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ * デバイスページングクエリ
+ *
+ * @author jason.w
+ */
+@Schema(description = "デバイスページングクエリ")
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class DevicePageQuery extends BasePageQuery {
+
+    @Schema(description = "店舗ID")
+    private Long storeId;
+
+    @Schema(description = "デバイスタイプ（PAYMENT_TERMINAL, CAMERA, GATE, REFRIGERATOR_SENSOR, PRINTER, NETWORK_ROUTER）")
+    private String deviceType;
+
+    @Schema(description = "ステータス（ONLINE, OFFLINE, ERROR, MAINTENANCE）")
+    private String status;
+
+    @Schema(description = "デバイス名（部分一致）")
+    private String deviceName;
+
+    @Schema(description = "デバイスコード（部分一致）")
+    private String deviceCode;
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/vo/DevicePageVO.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/model/vo/DevicePageVO.java
@@ -1,0 +1,52 @@
+package com.youlai.boot.modules.retail.model.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+/**
+ * デバイスページングVO
+ *
+ * @author jason.w
+ */
+@Schema(description = "デバイスページングVO")
+@Data
+public class DevicePageVO {
+
+    @Schema(description = "デバイスID")
+    private Long id;
+
+    @Schema(description = "店舗ID")
+    private Long storeId;
+
+    @Schema(description = "店舗名")
+    private String storeName;
+
+    @Schema(description = "デバイスコード")
+    private String deviceCode;
+
+    @Schema(description = "デバイスタイプ（PAYMENT_TERMINAL, CAMERA, GATE, REFRIGERATOR_SENSOR, PRINTER, NETWORK_ROUTER）")
+    private String deviceType;
+
+    @Schema(description = "デバイス名")
+    private String deviceName;
+
+    @Schema(description = "ステータス（ONLINE, OFFLINE, ERROR, MAINTENANCE）")
+    private String status;
+
+    @Schema(description = "最終Heartbeat受信日時")
+    private LocalDateTime lastHeartbeat;
+
+    @Schema(description = "エラーコード")
+    private String errorCode;
+
+    @Schema(description = "デバイス固有情報（JSON）")
+    private String metadata;
+
+    @Schema(description = "作成時間")
+    private LocalDateTime createTime;
+
+    @Schema(description = "更新時間")
+    private LocalDateTime updateTime;
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/service/DeviceService.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/service/DeviceService.java
@@ -1,0 +1,73 @@
+package com.youlai.boot.modules.retail.service;
+
+import com.youlai.boot.common.result.PageResult;
+import com.youlai.boot.modules.retail.model.entity.Device;
+import com.youlai.boot.modules.retail.model.form.DeviceForm;
+import com.youlai.boot.modules.retail.model.query.DevicePageQuery;
+import com.youlai.boot.modules.retail.model.vo.DevicePageVO;
+
+import java.util.List;
+
+/**
+ * デバイスサービスインターフェース
+ *
+ * @author jason.w
+ */
+public interface DeviceService {
+
+    /**
+     * デバイス一覧（ページング）取得
+     *
+     * @param queryParams クエリパラメータ
+     * @return ページング結果
+     */
+    PageResult<DevicePageVO> getDevicePage(DevicePageQuery queryParams);
+
+    /**
+     * デバイス一覧（全件）取得
+     *
+     * @return デバイスリスト
+     */
+    List<Device> listDevices();
+
+    /**
+     * 店舗別デバイス一覧取得
+     *
+     * @param storeId 店舗ID
+     * @return デバイスリスト
+     */
+    List<Device> listDevicesByStoreId(Long storeId);
+
+    /**
+     * デバイス詳細取得
+     *
+     * @param id デバイスID
+     * @return デバイス詳細
+     */
+    Device getDeviceById(Long id);
+
+    /**
+     * デバイス新規作成
+     *
+     * @param form デバイスフォーム
+     * @return 作成結果
+     */
+    boolean createDevice(DeviceForm form);
+
+    /**
+     * デバイス更新
+     *
+     * @param id   デバイスID
+     * @param form デバイスフォーム
+     * @return 更新結果
+     */
+    boolean updateDevice(Long id, DeviceForm form);
+
+    /**
+     * デバイス削除
+     *
+     * @param id デバイスID
+     * @return 削除結果
+     */
+    boolean deleteDevice(Long id);
+}

--- a/apps/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/DeviceServiceImpl.java
+++ b/apps/backend/src/main/java/com/youlai/boot/modules/retail/service/impl/DeviceServiceImpl.java
@@ -1,0 +1,167 @@
+package com.youlai.boot.modules.retail.service.impl;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.metadata.IPage;
+import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.youlai.boot.common.result.PageResult;
+import com.youlai.boot.modules.retail.converter.DeviceConverter;
+import com.youlai.boot.modules.retail.mapper.DeviceMapper;
+import com.youlai.boot.modules.retail.mapper.StoreMapper;
+import com.youlai.boot.modules.retail.model.entity.Device;
+import com.youlai.boot.modules.retail.model.entity.Store;
+import com.youlai.boot.modules.retail.model.form.DeviceForm;
+import com.youlai.boot.modules.retail.model.query.DevicePageQuery;
+import com.youlai.boot.modules.retail.model.vo.DevicePageVO;
+import com.youlai.boot.modules.retail.service.DeviceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * デバイスサービス実装クラス
+ *
+ * @author jason.w
+ */
+@Service
+@RequiredArgsConstructor
+public class DeviceServiceImpl extends ServiceImpl<DeviceMapper, Device> implements DeviceService {
+
+    private final DeviceConverter deviceConverter;
+    private final StoreMapper storeMapper;
+
+    @Override
+    public PageResult<DevicePageVO> getDevicePage(DevicePageQuery queryParams) {
+        Page<Device> page = new Page<>(queryParams.getPageNum(), queryParams.getPageSize());
+
+        LambdaQueryWrapper<Device> queryWrapper = new LambdaQueryWrapper<Device>()
+                .eq(queryParams.getStoreId() != null, Device::getStoreId, queryParams.getStoreId())
+                .eq(StringUtils.hasText(queryParams.getDeviceType()), Device::getDeviceType, queryParams.getDeviceType())
+                .eq(StringUtils.hasText(queryParams.getStatus()), Device::getStatus, queryParams.getStatus())
+                .like(StringUtils.hasText(queryParams.getDeviceName()), Device::getDeviceName, queryParams.getDeviceName())
+                .like(StringUtils.hasText(queryParams.getDeviceCode()), Device::getDeviceCode, queryParams.getDeviceCode())
+                .orderByAsc(Device::getStoreId)
+                .orderByAsc(Device::getDeviceType)
+                .orderByDesc(Device::getCreateTime);
+
+        IPage<Device> result = this.page(page, queryWrapper);
+
+        // 店舗名を取得するためのマップを作成
+        Set<Long> storeIds = result.getRecords().stream()
+                .map(Device::getStoreId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> storeNameMap = Map.of();
+        if (!storeIds.isEmpty()) {
+            List<Store> stores = storeMapper.selectBatchIds(storeIds);
+            storeNameMap = stores.stream()
+                    .collect(Collectors.toMap(Store::getId, Store::getStoreName));
+        }
+
+        Map<Long, String> finalStoreNameMap = storeNameMap;
+        List<DevicePageVO> list = result.getRecords().stream()
+                .map(device -> {
+                    DevicePageVO vo = deviceConverter.entity2Vo(device);
+                    vo.setStoreName(finalStoreNameMap.getOrDefault(device.getStoreId(), ""));
+                    return vo;
+                })
+                .collect(Collectors.toList());
+
+        return PageResult.success(list, result.getTotal());
+    }
+
+    @Override
+    public List<Device> listDevices() {
+        LambdaQueryWrapper<Device> queryWrapper = new LambdaQueryWrapper<Device>()
+                .orderByAsc(Device::getStoreId)
+                .orderByAsc(Device::getDeviceType)
+                .orderByDesc(Device::getCreateTime);
+        return this.list(queryWrapper);
+    }
+
+    @Override
+    public List<Device> listDevicesByStoreId(Long storeId) {
+        LambdaQueryWrapper<Device> queryWrapper = new LambdaQueryWrapper<Device>()
+                .eq(Device::getStoreId, storeId)
+                .orderByAsc(Device::getDeviceType)
+                .orderByDesc(Device::getCreateTime);
+        return this.list(queryWrapper);
+    }
+
+    @Override
+    public Device getDeviceById(Long id) {
+        return this.getById(id);
+    }
+
+    @Override
+    public boolean createDevice(DeviceForm form) {
+        Device device = deviceConverter.form2Entity(form);
+
+        // デバイスコードが未指定の場合は自動採番
+        if (!StringUtils.hasText(device.getDeviceCode())) {
+            device.setDeviceCode(generateDeviceCode(form.getStoreId(), form.getDeviceType()));
+        }
+
+        // デフォルトステータスを設定
+        if (!StringUtils.hasText(device.getStatus())) {
+            device.setStatus("OFFLINE");
+        }
+
+        return this.save(device);
+    }
+
+    @Override
+    public boolean updateDevice(Long id, DeviceForm form) {
+        Device device = deviceConverter.form2Entity(form);
+        device.setId(id);
+        return this.updateById(device);
+    }
+
+    @Override
+    public boolean deleteDevice(Long id) {
+        return this.removeById(id);
+    }
+
+    /**
+     * デバイスコードを自動採番
+     * フォーマット: DEV-{店舗ID}-{デバイスタイプ略称}-{連番}
+     *
+     * @param storeId    店舗ID
+     * @param deviceType デバイスタイプ
+     * @return デバイスコード
+     */
+    private String generateDeviceCode(Long storeId, String deviceType) {
+        String typeAbbr = getDeviceTypeAbbreviation(deviceType);
+
+        // 同じ店舗・タイプのデバイス数をカウント
+        LambdaQueryWrapper<Device> queryWrapper = new LambdaQueryWrapper<Device>()
+                .eq(Device::getStoreId, storeId)
+                .eq(Device::getDeviceType, deviceType);
+        long count = this.count(queryWrapper);
+
+        return String.format("DEV-%d-%s-%02d", storeId, typeAbbr, count + 1);
+    }
+
+    /**
+     * デバイスタイプの略称を取得
+     *
+     * @param deviceType デバイスタイプ
+     * @return 略称
+     */
+    private String getDeviceTypeAbbreviation(String deviceType) {
+        return switch (deviceType) {
+            case "PAYMENT_TERMINAL" -> "POS";
+            case "CAMERA" -> "CAM";
+            case "GATE" -> "GATE";
+            case "REFRIGERATOR_SENSOR" -> "REF";
+            case "PRINTER" -> "PRT";
+            case "NETWORK_ROUTER" -> "NET";
+            default -> "DEV";
+        };
+    }
+}

--- a/apps/backend/src/test/java/com/youlai/boot/modules/retail/controller/DeviceControllerRestAssuredTest.java
+++ b/apps/backend/src/test/java/com/youlai/boot/modules/retail/controller/DeviceControllerRestAssuredTest.java
@@ -1,0 +1,310 @@
+package com.youlai.boot.modules.retail.controller;
+
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * デバイス管理APIテスト
+ *
+ * @author jason.w
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DeviceControllerRestAssuredTest extends BaseControllerTest {
+
+    private static Long createdDeviceId;
+    private static Long testStoreId;
+
+    @BeforeEach
+    @Override
+    protected void setUp() {
+        super.setUp();
+        baseUrl = "/api/v1/retail/devices";
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("前提条件：店舗IDを取得")
+    void testGetStoreIdForTest() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 1)
+                .when()
+                .get("/api/v1/retail/stores/page");
+
+        prettyPrintJson("店舗一覧取得", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"));
+
+        if (response.path("data.list") != null && !((java.util.List<?>) response.path("data.list")).isEmpty()) {
+            Object idObj = ((Map<?, ?>) ((java.util.List<?>) response.path("data.list")).get(0)).get("id");
+            testStoreId = idObj instanceof Number ? ((Number) idObj).longValue() : Long.parseLong(idObj.toString());
+            System.out.println("テスト用店舗ID: " + testStoreId);
+        }
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("デバイス新規作成")
+    void testCreateDevice() {
+        if (testStoreId == null) {
+            System.out.println("店舗IDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Map<String, Object> deviceData = new HashMap<>();
+        deviceData.put("storeId", testStoreId);
+        deviceData.put("deviceType", "PAYMENT_TERMINAL");
+        deviceData.put("deviceName", "テスト決済端末1");
+        deviceData.put("status", "ONLINE");
+        deviceData.put("metadata", "{\"serial\":\"TEST-001\",\"model\":\"POS-X100\"}");
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .contentType("application/json")
+                .body(deviceData)
+                .when()
+                .post(baseUrl);
+
+        prettyPrintJson("デバイス新規作成", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("msg", anyOf(equalTo("Success"), equalTo("一切ok")));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("デバイス一覧取得（ページング）")
+    void testGetDevicePage() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 10)
+                .when()
+                .get(baseUrl + "/page");
+
+        prettyPrintJson("デバイス一覧取得（ページング）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data.list", notNullValue())
+                .body("data.total", greaterThanOrEqualTo(0));
+
+        if (response.path("data.list") != null && !((java.util.List<?>) response.path("data.list")).isEmpty()) {
+            Object idObj = ((Map<?, ?>) ((java.util.List<?>) response.path("data.list")).get(0)).get("id");
+            createdDeviceId = idObj instanceof Number ? ((Number) idObj).longValue() : Long.parseLong(idObj.toString());
+            System.out.println("取得したデバイスID: " + createdDeviceId);
+        }
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("デバイス一覧取得（全件）")
+    void testListDevices() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .when()
+                .get(baseUrl);
+
+        prettyPrintJson("デバイス一覧取得（全件）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data", notNullValue());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("店舗別デバイス一覧取得")
+    void testListDevicesByStoreId() {
+        if (testStoreId == null) {
+            System.out.println("店舗IDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .when()
+                .get(baseUrl + "/store/" + testStoreId);
+
+        prettyPrintJson("店舗別デバイス一覧取得", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data", notNullValue());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("デバイス詳細取得")
+    void testGetDevice() {
+        if (createdDeviceId == null) {
+            System.out.println("デバイスIDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .when()
+                .get(baseUrl + "/" + createdDeviceId);
+
+        prettyPrintJson("デバイス詳細取得", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data", notNullValue());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("デバイス更新")
+    void testUpdateDevice() {
+        if (createdDeviceId == null || testStoreId == null) {
+            System.out.println("デバイスIDまたは店舗IDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Map<String, Object> updateData = new HashMap<>();
+        updateData.put("storeId", testStoreId);
+        updateData.put("deviceType", "PAYMENT_TERMINAL");
+        updateData.put("deviceName", "テスト決済端末1（更新）");
+        updateData.put("status", "MAINTENANCE");
+        updateData.put("errorCode", "E001");
+        updateData.put("metadata", "{\"serial\":\"TEST-001\",\"model\":\"POS-X100\",\"firmware\":\"v2.0\"}");
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .contentType("application/json")
+                .body(updateData)
+                .when()
+                .put(baseUrl + "/" + createdDeviceId);
+
+        prettyPrintJson("デバイス更新", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"));
+    }
+
+    @Test
+    @Order(8)
+    @DisplayName("デバイス検索（店舗ID）")
+    void testSearchDeviceByStoreId() {
+        if (testStoreId == null) {
+            System.out.println("店舗IDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 10)
+                .queryParam("storeId", testStoreId)
+                .when()
+                .get(baseUrl + "/page");
+
+        prettyPrintJson("デバイス検索（店舗ID）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data.list", notNullValue());
+    }
+
+    @Test
+    @Order(9)
+    @DisplayName("デバイス検索（デバイスタイプ）")
+    void testSearchDeviceByDeviceType() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 10)
+                .queryParam("deviceType", "PAYMENT_TERMINAL")
+                .when()
+                .get(baseUrl + "/page");
+
+        prettyPrintJson("デバイス検索（デバイスタイプ）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data.list", notNullValue());
+    }
+
+    @Test
+    @Order(10)
+    @DisplayName("デバイス検索（ステータス）")
+    void testSearchDeviceByStatus() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 10)
+                .queryParam("status", "ONLINE")
+                .when()
+                .get(baseUrl + "/page");
+
+        prettyPrintJson("デバイス検索（ステータス）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data.list", notNullValue());
+    }
+
+    @Test
+    @Order(11)
+    @DisplayName("デバイス検索（デバイス名）")
+    void testSearchDeviceByDeviceName() {
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .queryParam("pageNum", 1)
+                .queryParam("pageSize", 10)
+                .queryParam("deviceName", "テスト")
+                .when()
+                .get(baseUrl + "/page");
+
+        prettyPrintJson("デバイス検索（デバイス名）", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"))
+                .body("data.list", notNullValue());
+    }
+
+    @Test
+    @Order(12)
+    @DisplayName("デバイス削除")
+    void testDeleteDevice() {
+        if (createdDeviceId == null) {
+            System.out.println("デバイスIDが取得できていないため、テストをスキップします");
+            return;
+        }
+
+        Response response = given()
+                .header("Authorization", bearerToken)
+                .when()
+                .delete(baseUrl + "/" + createdDeviceId);
+
+        prettyPrintJson("デバイス削除", response.getBody());
+
+        response.then()
+                .statusCode(200)
+                .body("code", equalTo("00000"));
+    }
+}


### PR DESCRIPTION
- Add DeviceController with CRUD endpoints
- Add DeviceService/DeviceServiceImpl
- Add DeviceForm, DevicePageQuery, DevicePageVO DTOs
- Add DeviceConverter (MapStruct)
- Add DeviceControllerRestAssuredTest (12 tests)

API Endpoints:
- GET /api/v1/retail/devices/page (pagination with filters)
- GET /api/v1/retail/devices (all devices)
- GET /api/v1/retail/devices/store/{storeId} (by store)
- GET /api/v1/retail/devices/{id} (detail)
- POST /api/v1/retail/devices (create)
- PUT /api/v1/retail/devices/{id} (update)
- DELETE /api/v1/retail/devices/{id} (delete)