### PR TITLE
Fix deployment script BASEPATH resolution and deploy workflow path matching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,12 @@ on:
   push:
     branches: [ main ]
     paths:
-      - 'frontend/**'
-      - 'backend/**'
+      - 'apps/frontend/**'
+      - 'apps/backend/**'
+      - 'platform/docker/**'
+      - 'front.sh'
+      - 'back.sh'
+      - '.github/workflows/deploy.yml'
 
 jobs:
   deploy:
@@ -19,7 +23,7 @@ jobs:
       - name: Check for frontend changes
         id: check_frontend
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q "^frontend/"; then
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -Eq "^(apps/frontend/|front\.sh$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -28,7 +32,7 @@ jobs:
       - name: Check for backend changes
         id: check_backend
         run: |
-          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q "^backend/"; then
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -Eq "^(apps/backend/|platform/docker/|back\.sh$)"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/back.sh
+++ b/back.sh
@@ -2,8 +2,33 @@
 
 set -e
 
+# Load BASEPATH and other shell envs.
+if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc"
+fi
+
 # Get script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ENV_FILE="${BASEPATH}/nginx/apps-env/mall-retail/platform/docker/.env.prod"
+
+if [ -z "$BASEPATH" ]; then
+    echo "Error: BASEPATH is not set"
+    exit 1
+fi
+
+if [ ! -d "$BASEPATH" ]; then
+    echo "Error: BASEPATH does not exist: $BASEPATH"
+    exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+    echo "Error: .env file not found at $ENV_FILE"
+    exit 1
+fi
+
+echo "Loaded from: $ENV_FILE"
+echo "BASEPATH: $BASEPATH"
 
 echo "Starting backend deployment..."
 
@@ -14,7 +39,7 @@ git pull
 cd "$SCRIPT_DIR/platform/docker"
 
 # Build and start backend
-docker compose -f docker-compose-app.yml up -d --build smart-retail-backend
+docker compose --env-file "$ENV_FILE" -f docker-compose-app.yml up -d --build smart-retail-backend
 
 echo ""
 echo "=== Backend deployment completed! ==="

--- a/back.sh
+++ b/back.sh
@@ -2,18 +2,59 @@
 
 set -e
 
-# Load BASEPATH and other shell envs.
-if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc"
-fi
-
 # Get script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+extract_basepath_from_file() {
+    local file="$1"
+    local line
+
+    [ -f "$file" ] || return 1
+
+    line="$(grep -E '^[[:space:]]*(export[[:space:]]+)?BASEPATH[[:space:]]*=' "$file" | tail -n 1 || true)"
+    [ -n "$line" ] || return 1
+
+    printf '%s\n' "$line" \
+        | sed -E "s/^[[:space:]]*(export[[:space:]]+)?BASEPATH[[:space:]]*=[[:space:]]*//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//"
+}
+
+resolve_basepath() {
+    local candidate=""
+    local source_file=""
+
+    if [ -n "${BASEPATH:-}" ]; then
+        BASEPATH_SOURCE="environment"
+        export BASEPATH
+        return 0
+    fi
+
+    for source_file in \
+        "$HOME/.bashrc" \
+        "$HOME/.bash_profile" \
+        "$HOME/.profile" \
+        "$HOME/.zshrc" \
+        "$HOME/.zprofile" \
+        "$SCRIPT_DIR/platform/docker/.env.prod" \
+        "$SCRIPT_DIR/platform/docker/.env"; do
+        candidate="$(extract_basepath_from_file "$source_file" || true)"
+        if [ -n "$candidate" ]; then
+            BASEPATH="$candidate"
+            BASEPATH_SOURCE="$source_file"
+            export BASEPATH
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_basepath || true
+
 ENV_FILE="${BASEPATH}/nginx/apps-env/mall-retail/platform/docker/.env.prod"
 
 if [ -z "$BASEPATH" ]; then
     echo "Error: BASEPATH is not set"
+    echo "Checked environment, shell profile files, and project .env files."
     exit 1
 fi
 
@@ -29,6 +70,7 @@ fi
 
 echo "Loaded from: $ENV_FILE"
 echo "BASEPATH: $BASEPATH"
+echo "BASEPATH source: ${BASEPATH_SOURCE:-unknown}"
 
 echo "Starting backend deployment..."
 

--- a/front.sh
+++ b/front.sh
@@ -2,12 +2,6 @@
 
 set -e
 
-# Load BASEPATH and other shell envs.
-if [ -f "$HOME/.bashrc" ]; then
-    # shellcheck source=/dev/null
-    source "$HOME/.bashrc"
-fi
-
 # Setup Node.js (Volta)
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
@@ -16,10 +10,57 @@ echo "npm version: $(npm -v)"
 
 # Get script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+extract_basepath_from_file() {
+    local file="$1"
+    local line
+
+    [ -f "$file" ] || return 1
+
+    line="$(grep -E '^[[:space:]]*(export[[:space:]]+)?BASEPATH[[:space:]]*=' "$file" | tail -n 1 || true)"
+    [ -n "$line" ] || return 1
+
+    printf '%s\n' "$line" \
+        | sed -E "s/^[[:space:]]*(export[[:space:]]+)?BASEPATH[[:space:]]*=[[:space:]]*//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//"
+}
+
+resolve_basepath() {
+    local candidate=""
+    local source_file=""
+
+    if [ -n "${BASEPATH:-}" ]; then
+        BASEPATH_SOURCE="environment"
+        export BASEPATH
+        return 0
+    fi
+
+    for source_file in \
+        "$HOME/.bashrc" \
+        "$HOME/.bash_profile" \
+        "$HOME/.profile" \
+        "$HOME/.zshrc" \
+        "$HOME/.zprofile" \
+        "$SCRIPT_DIR/platform/docker/.env.prod" \
+        "$SCRIPT_DIR/platform/docker/.env"; do
+        candidate="$(extract_basepath_from_file "$source_file" || true)"
+        if [ -n "$candidate" ]; then
+            BASEPATH="$candidate"
+            BASEPATH_SOURCE="$source_file"
+            export BASEPATH
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_basepath || true
+
 ENV_FILE="${BASEPATH}/nginx/apps-env/mall-retail/platform/docker/.env.prod"
 
 if [ -z "$BASEPATH" ]; then
     echo "Error: BASEPATH is not set"
+    echo "Checked environment, shell profile files, and project .env files."
     exit 1
 fi
 
@@ -35,6 +76,7 @@ fi
 
 echo "Loaded from: $ENV_FILE"
 echo "BASEPATH: $BASEPATH"
+echo "BASEPATH source: ${BASEPATH_SOURCE:-unknown}"
 
 # Deploy directory
 DEPLOY_DIR="$BASEPATH/nginx/html/retail"

--- a/front.sh
+++ b/front.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+# Load BASEPATH and other shell envs.
+if [ -f "$HOME/.bashrc" ]; then
+    # shellcheck source=/dev/null
+    source "$HOME/.bashrc"
+fi
+
 # Setup Node.js (Volta)
 export VOLTA_HOME="$HOME/.volta"
 export PATH="$VOLTA_HOME/bin:$PATH"
@@ -10,23 +16,25 @@ echo "npm version: $(npm -v)"
 
 # Get script directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ENV_FILE="$SCRIPT_DIR/platform/docker/.env"
+ENV_FILE="${BASEPATH}/nginx/apps-env/mall-retail/platform/docker/.env.prod"
 
-# Load BASEPATH from .env
-if [ -f "$ENV_FILE" ]; then
-    BASEPATH=$(grep '^BASEPATH=' "$ENV_FILE" | cut -d '=' -f2-)
-    echo "Loaded from: $ENV_FILE"
-    echo "BASEPATH: $BASEPATH"
-else
+if [ -z "$BASEPATH" ]; then
+    echo "Error: BASEPATH is not set"
+    exit 1
+fi
+
+if [ ! -d "$BASEPATH" ]; then
+    echo "Error: BASEPATH does not exist: $BASEPATH"
+    exit 1
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
     echo "Error: .env file not found at $ENV_FILE"
     exit 1
 fi
 
-# Validate BASEPATH
-if [ -z "$BASEPATH" ]; then
-    echo "Error: BASEPATH is not set in .env"
-    exit 1
-fi
+echo "Loaded from: $ENV_FILE"
+echo "BASEPATH: $BASEPATH"
 
 # Deploy directory
 DEPLOY_DIR="$BASEPATH/nginx/html/retail"


### PR DESCRIPTION
## Summary
- make `back.sh` and `front.sh` resolve `BASEPATH` reliably in non-interactive SSH sessions
- keep the deployment scripts validating the resolved path and env file before proceeding
- update the GitHub Actions deploy workflow to watch the actual repo paths under `apps/...`
- include deploy script and workflow changes in the trigger rules so CI/CD runs when deployment logic changes

## Testing
- `bash -n back.sh`
- `bash -n front.sh`

## Notes
- this includes the earlier `.env.prod` deployment-script change already on `develop`
- `develop` is currently 2 commits ahead of `main`